### PR TITLE
#24 pre-cache enviroment prior to verifyWithHCaptcha call

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 2.1.0
 
-- Add `HCaptcha.setup` method ([#24](https://github.com/hCaptcha/hcaptcha-android-sdk/issues/24))
+- Add `HCaptcha.setup` method to improve cold-start time, enable asset caching ([#24](https://github.com/hCaptcha/hcaptcha-android-sdk/issues/24))
 
 ## 2.0.0
 - Add more error codes (see readme for full list)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 # Changelog
 
+## 2.1.0
+
+- Add `HCaptcha.setup` method ([#24](https://github.com/hCaptcha/hcaptcha-android-sdk/issues/24))
+
 ## 2.0.0
 - Add more error codes (see readme for full list)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ And then simply call:
 HCaptcha.getClient(this).verifyWithHCaptcha()...
 ```
 
-If you need to customize the look and feel, language, endpoint, etc. this can be achieved by passing a `HCaptchaConfig` object to `getClient` method.
+If you need to customize the look and feel, language, endpoint, etc. this can be achieved by passing a `HCaptchaConfig` object to `verifyWithHCaptcha` method.
 
 ```java
 final HCaptchaConfig config = HCaptchaConfig.builder()
@@ -95,7 +95,7 @@ final HCaptchaConfig config = HCaptchaConfig.builder()
 HCaptcha.getClient(this).verifyWithHCaptcha(config)...;
 ```
 
-Also to improve hCaptcha start time with `setup` like this:
+Also to reduce hCaptcha start time, `setup` can be used:
 
 ```java
 HCaptcha hCaptcha = HCaptcha.getClient(this).setup()

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following snippet code will ask the user to complete a challenge.
 import com.hcaptcha.sdk.*;
 import com.hcaptcha.sdk.tasks.*;
 
-HCaptcha.getClient(this, YOUR_API_SITE_KEY).verifyWithHCaptcha()
+HCaptcha.getClient(this).verifyWithHCaptcha(YOUR_API_SITE_KEY)
     .addOnSuccessListener(new OnSuccessListener<HCaptchaTokenResponse>() {
         @Override
         public void onSuccess(HCaptchaTokenResponse response) {
@@ -92,8 +92,18 @@ final HCaptchaConfig config = HCaptchaConfig.builder()
                 .resetOnTimeout(true)
                 .theme(HCaptchaTheme.DARK)
                 .build();
-HCaptcha.getClient(this, config).verifyWithHCaptcha()...;
+HCaptcha.getClient(this).verifyWithHCaptcha(config)...;
 ```
+
+Also to improve hCaptcha start time with `setup` like this:
+
+```java
+HCaptcha hCaptcha = HCaptcha.getClient(this).setup()
+```
+
+`setup` accepts the same arguments as `verifyWithHCaptcha`. Once `setup` is called, later you can call `verifyWithHCaptcha` with no arguments
+
+If `verifyWithHCaptcha` will be called with different arguments than `setup`, SDK will handle this and re-configure hCaptcha.
 
 ##### Config params
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ HCaptcha hCaptcha = HCaptcha.getClient(this).setup()
 
 `setup` accepts the same arguments as `verifyWithHCaptcha`. Once `setup` is called, later you can call `verifyWithHCaptcha` with no arguments
 
-If `verifyWithHCaptcha` will be called with different arguments than `setup`, SDK will handle this and re-configure hCaptcha.
+If `verifyWithHCaptcha` is called with different arguments than `setup` the SDK will handle this by re-configuring hCaptcha. Note that this will reduce some of the performance benefit of using `setup`.
 
 ##### Config params
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following snippet code will ask the user to complete a challenge.
 import com.hcaptcha.sdk.*;
 import com.hcaptcha.sdk.tasks.*;
 
-HCaptcha.getClient(this).verifyWithHCaptcha(YOUR_API_SITE_KEY)
+HCaptcha.getClient(this, YOUR_API_SITE_KEY).verifyWithHCaptcha()
     .addOnSuccessListener(new OnSuccessListener<HCaptchaTokenResponse>() {
         @Override
         public void onSuccess(HCaptchaTokenResponse response) {
@@ -60,7 +60,28 @@ HCaptcha.getClient(this).verifyWithHCaptcha(YOUR_API_SITE_KEY)
     });
 ```
 
-You can also customize the look and feel, language, endpoint, etc. by passing a `HCaptchaConfig` object to `verifyWithHCaptcha` method.
+You can also pass `YOUR_API_SITE_KEY` via `AndroidManifest.xml` like this:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest ...>
+    ...
+    <application ...>
+        <meta-data
+            android:name="com.hcaptcha.sdk.site-key"
+            android:value="YOUR_API_SITE_KEY" />
+       ...
+    </application>
+</manifest>
+```
+
+And then simply call:
+
+```java
+HCaptcha.getClient(this).verifyWithHCaptcha()...
+```
+
+If you need to customize the look and feel, language, endpoint, etc. this can be achieved by passing a `HCaptchaConfig` object to `getClient` method.
 
 ```java
 final HCaptchaConfig config = HCaptchaConfig.builder()
@@ -71,7 +92,7 @@ final HCaptchaConfig config = HCaptchaConfig.builder()
                 .resetOnTimeout(true)
                 .theme(HCaptchaTheme.DARK)
                 .build();
-HCaptcha.getClient(this).verifyWithHCaptcha(config)...;
+HCaptcha.getClient(this, config).verifyWithHCaptcha()...;
 ```
 
 ##### Config params

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -29,10 +29,10 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+
     implementation project(path: ':sdk')
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/example-app/src/main/AndroidManifest.xml
+++ b/example-app/src/main/AndroidManifest.xml
@@ -11,8 +11,14 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+
+        <meta-data
+            android:name="com.hcaptcha.sdk.site-key"
+            android:value="10000000-ffff-ffff-ffff-000000000001" />
+
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/example-app/src/main/java/com/hcaptcha/example/MainActivity.java
+++ b/example-app/src/main/java/com/hcaptcha/example/MainActivity.java
@@ -3,7 +3,10 @@ package com.hcaptcha.example;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
+import android.widget.RadioGroup;
 import android.widget.TextView;
+
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import com.hcaptcha.sdk.*;
 import com.hcaptcha.sdk.tasks.OnFailureListener;
@@ -18,6 +21,8 @@ public class MainActivity extends AppCompatActivity {
 
     private TextView errorTextView;
 
+    private HCaptcha hCaptcha;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -26,6 +31,25 @@ public class MainActivity extends AppCompatActivity {
         this.errorTextView = findViewById(R.id.errorTextView);
         // For debugging purposes only
         // android.webkit.WebView.setWebContentsDebuggingEnabled(true);
+
+        initHCaptcha(HCaptchaSize.INVISIBLE);
+        RadioGroup sizes = findViewById(R.id.sizes);
+        sizes.check(R.id.size_invisible);
+    }
+
+    private void initHCaptcha(@Nullable HCaptchaSize size) {
+        if (size == null) {
+            hCaptcha = HCaptcha.getClient(this);
+            return;
+        }
+
+        final String YOUR_API_SITE_KEY = "10000000-ffff-ffff-ffff-000000000001";
+        final HCaptchaConfig config = HCaptchaConfig.builder()
+                .siteKey(YOUR_API_SITE_KEY)
+                .size(size)
+                .loading(true)
+                .build();
+        hCaptcha = HCaptcha.getClient(this, config);
     }
 
     private void setTokenTextView(final String text) {
@@ -39,26 +63,24 @@ public class MainActivity extends AppCompatActivity {
     }
 
     public void onClickHCaptchaInvisible(View v) {
-        onClickHCaptcha(HCaptchaSize.INVISIBLE);
+        initHCaptcha(HCaptchaSize.INVISIBLE);
     }
 
     public void onClickHCaptchaCompact(View v) {
-        onClickHCaptcha(HCaptchaSize.COMPACT);
+        initHCaptcha(HCaptchaSize.COMPACT);
     }
 
     public void onClickHCaptchaNormal(View v) {
-        onClickHCaptcha(HCaptchaSize.NORMAL);
+        initHCaptcha(HCaptchaSize.NORMAL);
     }
 
-    public void onClickHCaptcha(final HCaptchaSize hCaptchaSize) {
+    public void onClickHCaptchaNull(View v) {
+        initHCaptcha(null);
+    }
+
+    public void onClickShowHCaptcha(final View v) {
         setTokenTextView("-");
-        final String YOUR_API_SITE_KEY = "10000000-ffff-ffff-ffff-000000000001";
-        final HCaptchaConfig config = HCaptchaConfig.builder()
-                .siteKey(YOUR_API_SITE_KEY)
-                .size(hCaptchaSize)
-                .loading(true)
-                .build();
-        HCaptcha.getClient(this).verifyWithHCaptcha(config)
+        hCaptcha.verifyWithHCaptcha()
                 .addOnSuccessListener(new OnSuccessListener<HCaptchaTokenResponse>() {
                     @Override
                     public void onSuccess(HCaptchaTokenResponse response) {

--- a/example-app/src/main/res/layout/activity_main.xml
+++ b/example-app/src/main/res/layout/activity_main.xml
@@ -7,33 +7,39 @@
     android:theme="@style/Theme.AppCompat"
     tools:context=".MainActivity">
 
-    <LinearLayout
-        android:orientation="horizontal"
+    <RadioGroup
+        android:id="@+id/sizes"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <Button
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <RadioButton
+            android:id="@+id/size_invisible"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="HCaptcha&#10;(invisible)"
-            android:textSize="12sp"
-            android:onClick="onClickHCaptchaInvisible" />
-
-        <Button
+            android:text="@string/size_invisible"
+            android:onClick="onClickHCaptchaInvisible"/>
+        <RadioButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="HCaptcha&#10;(compact)"
-            android:textSize="12sp"
-            android:onClick="onClickHCaptchaCompact" />
-
-        <Button
+            android:text="@string/size_compact"
+            android:onClick="onClickHCaptchaCompact"/>
+        <RadioButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="HCaptcha&#10;(normal)"
-            android:textSize="12sp"
-            android:onClick="onClickHCaptchaNormal" />
+            android:text="@string/size_normal"
+            android:onClick="onClickHCaptchaNormal"/>
+        <RadioButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/size_null"
+            android:onClick="onClickHCaptchaNull"/>
+    </RadioGroup>
 
-    </LinearLayout>
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/show_hcaptcha"
+        android:onClick="onClickShowHCaptcha" />
 
     <LinearLayout
         android:background="@android:color/holo_green_light"

--- a/example-app/src/main/res/layout/activity_main.xml
+++ b/example-app/src/main/res/layout/activity_main.xml
@@ -8,7 +8,7 @@
     tools:context=".MainActivity">
 
     <RadioGroup
-        android:id="@+id/sizes"
+        android:id="@+id/sizeRadioGroup"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal">
@@ -16,24 +16,43 @@
             android:id="@+id/size_invisible"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/size_invisible"
-            android:onClick="onClickHCaptchaInvisible"/>
+            android:text="@string/size_invisible"/>
         <RadioButton
+            android:id="@+id/size_compact"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/size_compact"
-            android:onClick="onClickHCaptchaCompact"/>
+            android:text="@string/size_compact"/>
         <RadioButton
+            android:id="@+id/size_normal"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/size_normal"
-            android:onClick="onClickHCaptchaNormal"/>
+            android:text="@string/size_normal"/>
         <RadioButton
+            android:id="@+id/size_default"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/size_null"
-            android:onClick="onClickHCaptchaNull"/>
+            android:text="@string/size_default"/>
     </RadioGroup>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+        <CheckBox
+            android:id="@+id/setupCheckBox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:checked="true"
+            android:text="@string/setup" />
+        <CheckBox
+            android:id="@+id/webViewDebug"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:checked="false"
+            android:text="@string/web_view_debug" />
+    </LinearLayout>
 
     <Button
         android:layout_width="match_parent"
@@ -59,6 +78,7 @@
             android:id="@+id/tokenTextView"
             android:text="-"
             android:textColor="@android:color/white"
+            android:ellipsize="end"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
     </LinearLayout>

--- a/example-app/src/main/res/layout/activity_main.xml
+++ b/example-app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -16,22 +17,27 @@
             android:id="@+id/size_invisible"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/size_invisible"/>
+            android:text="@string/size_invisible"
+            style="@style/CheckBoxText" />
         <RadioButton
             android:id="@+id/size_compact"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/size_compact"/>
+            android:text="@string/size_compact"
+            style="@style/CheckBoxText" />
         <RadioButton
             android:id="@+id/size_normal"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/size_normal"/>
+            android:text="@string/size_normal"
+            style="@style/CheckBoxText" />
         <RadioButton
             android:id="@+id/size_default"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/size_default"/>
+            android:text="@string/size_default"
+            app:buttonTint="@color/colorAccent"
+            style="@style/CheckBoxText" />
     </RadioGroup>
 
     <LinearLayout
@@ -44,14 +50,16 @@
             android:layout_height="wrap_content"
             android:minHeight="48dp"
             android:checked="true"
-            android:text="@string/setup" />
+            android:text="@string/setup"
+            style="@style/CheckBoxText" />
         <CheckBox
             android:id="@+id/webViewDebug"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:minHeight="48dp"
             android:checked="false"
-            android:text="@string/web_view_debug" />
+            android:text="@string/web_view_debug"
+            style="@style/CheckBoxText" />
     </LinearLayout>
 
     <Button
@@ -79,6 +87,7 @@
             android:text="-"
             android:textColor="@android:color/white"
             android:ellipsize="end"
+            android:maxLines="1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
     </LinearLayout>

--- a/example-app/src/main/res/values/strings.xml
+++ b/example-app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
     <string name="size_invisible">Invisible</string>
     <string name="size_compact">Compact</string>
     <string name="size_normal">Normal</string>
-    <string name="size_null">Null</string>
+    <string name="size_default">Default</string>
+    <string name="setup">Setup</string>
     <string name="show_hcaptcha">Show</string>
+    <string name="web_view_debug">WebView Debug</string>
 </resources>

--- a/example-app/src/main/res/values/strings.xml
+++ b/example-app/src/main/res/values/strings.xml
@@ -1,3 +1,8 @@
 <resources>
     <string name="app_name">Example hCaptcha App</string>
+    <string name="size_invisible">Invisible</string>
+    <string name="size_compact">Compact</string>
+    <string name="size_normal">Normal</string>
+    <string name="size_null">Null</string>
+    <string name="show_hcaptcha">Show</string>
 </resources>

--- a/example-app/src/main/res/values/styles.xml
+++ b/example-app/src/main/res/values/styles.xml
@@ -1,10 +1,17 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:app="http://schemas.android.com/apk/res-auto">
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+
+        <!-- https://stackoverflow.com/questions/62696305 -->
+        <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
     </style>
 
+    <style name="CheckBoxText" parent="TextAppearance.AppCompat">
+        <item name="android:textColor">#222222</item>
+        <item name="android:buttonTint" tools:ignore="NewApi">@color/colorAccent</item>
+    </style>
 </resources>

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,11 +12,11 @@ android {
         // See https://developer.android.com/studio/publish/versioning
         // versionCode must be integer and be incremented by one for every new update
         // android system uses this to prevent downgrades
-        versionCode 10
+        versionCode 11
 
         // version number visible to the user
         // should follow semantic versioning (See https://semver.org)
-        versionName "2.0.0"
+        versionName "2.1.0"
 
         buildConfigField 'String', 'VERSION_NAME', "\"${defaultConfig.versionName}_${defaultConfig.versionCode}\""
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.16'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:3.6.28'
+    testImplementation 'org.mockito:mockito-inline:3.6.28'
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
 
     androidTestImplementation 'androidx.test:core:1.4.0'

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptcha.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptcha.java
@@ -2,6 +2,10 @@ package com.hcaptcha.sdk;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -35,60 +39,19 @@ import com.hcaptcha.sdk.tasks.Task;
  *  </pre>
  */
 public class HCaptcha extends Task<HCaptchaTokenResponse> {
+    public static final String META_SITE_KEY = "com.hcaptcha.sdk.site-key";
 
     private final FragmentManager fragmentManager;
 
-    private HCaptcha(@NonNull final Activity activity) {
-        this((Context) activity);
+    private final HCaptchaDialogFragment hCaptchaDialogFragment;
+
+    private HCaptcha(@NonNull final Context context, @NonNull final HCaptchaConfig hCaptchaConfig) {
+        this(((FragmentActivity) context).getSupportFragmentManager(), hCaptchaConfig);
     }
 
-    private HCaptcha(@NonNull final Context context) {
-        this(((FragmentActivity) context).getSupportFragmentManager());
-    }
-
-    private HCaptcha(@NonNull final FragmentManager fragmentManager) {
+    private HCaptcha(@NonNull final FragmentManager fragmentManager, @NonNull final HCaptchaConfig hCaptchaConfig) {
         this.fragmentManager = fragmentManager;
-    }
-
-    /**
-     * Constructs a new client which allows to display a challenge dialog
-     *
-     * @param context The current context
-     * @return new {@link HCaptcha} object
-     */
-    public static HCaptcha getClient(@NonNull final Context context) {
-        return new HCaptcha(context);
-    }
-
-    /**
-     * Constructs a new client which allows to display a challenge dialog
-     *
-     * @param activity The current activity
-     * @return new {@link HCaptcha} object
-     */
-    public static HCaptcha getClient(@NonNull final Activity activity) {
-        return new HCaptcha(activity);
-    }
-
-    /**
-     * Shows a captcha challenge dialog to be completed by the user
-     *
-     * @param siteKey The hCaptcha site-key. Get one here <a href="https://www.hcaptcha.com">hcaptcha.com</a>
-     * @return {@link HCaptcha}
-     */
-    public HCaptcha verifyWithHCaptcha(@NonNull final String siteKey) {
-        final HCaptchaConfig hCaptchaConfig = HCaptchaConfig.builder().siteKey(siteKey).build();
-        return verifyWithHCaptcha(hCaptchaConfig);
-    }
-
-    /**
-     * Shows a captcha challenge dialog to be completed by the user
-     *
-     * @param hCaptchaConfig Config to customize: size, theme, locale, endpoint, rqdata, etc.
-     * @return {@link HCaptcha}
-     */
-    public HCaptcha verifyWithHCaptcha(@NonNull final HCaptchaConfig hCaptchaConfig) {
-        final HCaptchaDialogFragment hCaptchaDialogFragment = HCaptchaDialogFragment.newInstance(hCaptchaConfig, new HCaptchaDialogListener() {
+        this.hCaptchaDialogFragment = HCaptchaDialogFragment.newInstance(hCaptchaConfig, new HCaptchaDialogListener() {
             @Override
             void onSuccess(final HCaptchaTokenResponse hCaptchaTokenResponse) {
                 setResult(hCaptchaTokenResponse);
@@ -99,6 +62,61 @@ public class HCaptcha extends Task<HCaptchaTokenResponse> {
                 setException(hCaptchaException);
             }
         });
+    }
+
+    /**
+     * Constructs a new client which allows to display a challenge dialog
+     *
+     * @param context The current context
+     * @return new {@link HCaptcha} object
+     */
+    public static HCaptcha getClient(@NonNull final Context context) {
+        String siteKey = null;
+        try {
+            ApplicationInfo app = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+            Bundle bundle = app.metaData;
+            siteKey = bundle.getString(META_SITE_KEY);
+        } catch (PackageManager.NameNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+
+        if (siteKey == null) {
+            throw new IllegalStateException("Add missing " + META_SITE_KEY + " meta-data to AndroidManifest.xml"
+                    + " or call getClient(context, siteKey) method");
+        }
+
+        return getClient(context, siteKey);
+    }
+
+    /**
+     * Constructs a new client which allows to display a challenge dialog
+     *
+     * @param context The current context
+     * @param siteKey The hCaptcha site-key. Get one here <a href="https://www.hcaptcha.com">hcaptcha.com</a>
+     * @return new {@link HCaptcha} object
+     */
+    public static HCaptcha getClient(@NonNull final Context context, @NonNull final String siteKey) {
+        final HCaptchaConfig hCaptchaConfig = HCaptchaConfig.builder().siteKey(siteKey).build();
+        return getClient(context, hCaptchaConfig);
+    }
+
+    /**
+     * Constructs a new client which allows to display a challenge dialog
+     *
+     * @param context The current context
+     * @param hCaptchaConfig Config to customize: size, theme, locale, endpoint, rqdata, etc.
+     * @return new {@link HCaptcha} object
+     */
+    public static HCaptcha getClient(@NonNull final Context context, @NonNull final HCaptchaConfig hCaptchaConfig) {
+        return new HCaptcha(context, hCaptchaConfig);
+    }
+
+    /**
+     * Shows a captcha challenge dialog to be completed by the user
+     *
+     * @return {@link HCaptcha}
+     */
+    public HCaptcha verifyWithHCaptcha() {
         hCaptchaDialogFragment.show(fragmentManager, HCaptchaDialogFragment.TAG);
         return this;
     }

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptcha.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptcha.java
@@ -72,7 +72,6 @@ public class HCaptcha extends Task<HCaptchaTokenResponse> {
     /**
      * Prepare the client which allows to display a challenge dialog
      *
-     * @param context The current context
      * @return new {@link HCaptcha} object
      */
     public HCaptcha setup() {

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaDialogFragment.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaDialogFragment.java
@@ -152,8 +152,9 @@ public class HCaptchaDialogFragment extends DialogFragment implements
         final WebSettings settings = webView.getSettings();
         settings.setJavaScriptEnabled(true);
         settings.setLoadWithOverviewMode(true);
+        settings.setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
         webView.setBackgroundColor(Color.TRANSPARENT);
-        webView.setLayerType(WebView.LAYER_TYPE_SOFTWARE, null);
+        webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
         webView.addJavascriptInterface(hCaptchaJsInterface, HCaptchaJSInterface.JS_INTERFACE_TAG);
         webView.addJavascriptInterface(hCaptchaDebugInfo, HCaptchaDebugInfo.JS_INTERFACE_TAG);
         webView.loadUrl("file:///android_asset/hcaptcha-form.html");

--- a/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaConfigTest.java
+++ b/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaConfigTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertNull;
 
 public class HCaptchaConfigTest {
 
-    private static final String MOCK_SITE_KEY = "mocked-site-key";
+    public static final String MOCK_SITE_KEY = "mocked-site-key";
 
     @Test
     public void custom_locale() {

--- a/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaTest.java
+++ b/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaTest.java
@@ -1,19 +1,33 @@
 package com.hcaptcha.sdk;
 
-import android.content.Context;
+import static com.hcaptcha.sdk.HCaptcha.META_SITE_KEY;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
 import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Locale;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -22,24 +36,80 @@ public class HCaptchaTest {
     @Mock
     FragmentActivity fragmentActivity;
 
+    @Mock
+    PackageManager packageManager;
+
+    @Mock
+    FragmentManager fragmentManager;
+
     @Captor
     ArgumentCaptor<HCaptchaConfig> hCaptchaConfigCaptor;
 
+    MockedStatic<HCaptchaDialogFragment> dialogFragmentMock;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.openMocks(this);
+
+        dialogFragmentMock = mockStatic(HCaptchaDialogFragment.class);
+    }
+
+    @After
+    public void release() {
+        dialogFragmentMock.close();
+    }
+
     @Test
-    public void test_client_creation_via_context_and_activity() {
-        assertNotNull(HCaptcha.getClient((Context) fragmentActivity));
+    public void test_client_creation_via_activity() {
+        dialogFragmentMock.when(() ->
+                    HCaptchaDialogFragment.newInstance(any(HCaptchaConfig.class), any(HCaptchaDialogListener.class))).thenReturn(mock(HCaptchaDialogFragment.class));
+
+        assertNotNull(HCaptcha.getClient(fragmentActivity, HCaptchaConfigTest.MOCK_SITE_KEY));
+    }
+
+    @Test
+    public void test_site_key_from_metadata() throws Exception {
+        dialogFragmentMock
+                .when(() ->
+                        HCaptchaDialogFragment.newInstance(any(HCaptchaConfig.class), any(HCaptchaDialogListener.class)))
+                .thenReturn(mock(HCaptchaDialogFragment.class));
+
+        ApplicationInfo applicationInfo = mock(ApplicationInfo.class);
+        Bundle bundle = mock(Bundle.class);
+        when(bundle.getString(META_SITE_KEY)).thenReturn(HCaptchaConfigTest.MOCK_SITE_KEY);
+        bundle.putString(META_SITE_KEY, HCaptchaConfigTest.MOCK_SITE_KEY);
+        applicationInfo.metaData = bundle;
+
+        String packageName = "com.hcaptcha.sdk.test";
+        when(fragmentActivity.getPackageName()).thenReturn(packageName);
+        when(fragmentActivity.getPackageManager()).thenReturn(packageManager);
+        when(packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA))
+                .thenReturn(applicationInfo);
+
         assertNotNull(HCaptcha.getClient(fragmentActivity));
     }
 
     @Test
     public void test_verify_with_hcaptcha_passes_site_key_as_config() {
-        final String siteKey = "mock-site-key";
-        final HCaptcha hCaptcha = spy(HCaptcha.getClient(fragmentActivity));
-        doReturn(hCaptcha).when(hCaptcha).verifyWithHCaptcha(hCaptchaConfigCaptor.capture());
-        hCaptcha.verifyWithHCaptcha(siteKey);
+        when(fragmentActivity.getSupportFragmentManager()).thenReturn(fragmentManager);
+        HCaptchaDialogFragment fragment = mock(HCaptchaDialogFragment.class);
+        dialogFragmentMock
+                .when(() -> HCaptchaDialogFragment.newInstance(any(HCaptchaConfig.class), any(HCaptchaDialogListener.class)))
+                .thenReturn(fragment);
+
+        final String siteKey = HCaptchaConfigTest.MOCK_SITE_KEY;
+        final HCaptcha hCaptcha = HCaptcha.getClient(fragmentActivity, siteKey);
+
+        hCaptcha.verifyWithHCaptcha();
+
+        dialogFragmentMock.verify(() ->
+                HCaptchaDialogFragment.newInstance(hCaptchaConfigCaptor.capture(), any(HCaptchaDialogListener.class)));
+        verify(fragment).show(fragmentManager, HCaptchaDialogFragment.TAG);
+
         final HCaptchaConfig config = hCaptchaConfigCaptor.getValue();
         assertNotNull(config);
         assertEquals(siteKey, config.getSiteKey());
+
         // Rest of params must be the defaults
         final String locale = Locale.getDefault().getLanguage();
         assertEquals(HCaptchaSize.INVISIBLE, config.getSize());
@@ -48,5 +118,4 @@ public class HCaptchaTest {
         assertEquals(locale, config.getLocale());
         assertEquals("https://js.hcaptcha.com/1/api.js", config.getApiEndpoint());
     }
-
 }


### PR DESCRIPTION
Closing https://github.com/hCaptcha/hcaptcha-android-sdk/issues/24 
 
 - Fragment instantiation now happens on `new HCaptcha`
 - WebView to use cache before reaching network
 - Update sample application