### PR TITLE
Add retry with parallels for UI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,6 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: Nexus 6
-          script: ./gradlew connectedCheck
+          script: |
+            brew install parallel
+            parallel --retries 5 ::: "./gradlew connectedCheck"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
           profile: Nexus 6
           script: |
             brew install parallel
-            parallel --retries 5 ::: "./gradlew connectedCheck"
+            parallel --retries 3 ::: "./gradlew connectedCheck"


### PR DESCRIPTION
### Intro

 - GitHub Actions CI doesn't support retry for steps
 - We can retry shell scripts but this is not an option for `android-emulator-runner` step
 - android-emulator-runner action also doesn't have any input to retry tests

`parallels` should help to retry as part of the script of `android-emulator-runner` step