### PR TITLE
Feature/watch sdk size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,26 @@ jobs:
           script: |
             brew install parallel
             parallel --retries 3 ::: "./gradlew connectedCheck"
+  size-report:
+    name: Diffuse report
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: adopt
+        cache: 'gradle'
+    - name: Build sdk for PR and main branch
+      run: |
+        ./gradlew build --stacktrace
+        cp sdk/build/outputs/aar/sdk-release.aar sdk-pr.aar
+        git checkout origin/main
+        ./gradlew build --stacktrace
+        cp sdk/build/outputs/aar/sdk-release.aar sdk-main.aar
+    - name: Diffuse report
+      run: |
+        wget https://github.com/JakeWharton/diffuse/releases/download/0.1.0/diffuse-0.1.0-binary.jar
+        java -jar diffuse-0.1.0-binary.jar diff --aar sdk-main.aar sdk-pr.aar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Android SDK CI
-on: push
+on:
+  push:
+    branches: [ main ]
+  pull_request:
 jobs:
   build:
     name: Build & Unit-test
@@ -12,13 +15,20 @@ jobs:
           distribution: adopt
           cache: 'gradle'
       - name: Assemble & Test
-        run: ./gradlew build --stacktrace
+        run: |
+          ./gradlew build --stacktrace
+          cp sdk/build/outputs/aar/sdk-release.aar sdk-main.aar
       - name: HTML ES5 test
         run: |
           npm install -g jshint
           jshint --extract=always sdk/src/main/assets/hcaptcha-form.html
       - name: JitPack Test
         run: ./gradlew publishReleasePublicationToMavenLocal
+      - if: github.event_name == 'push'
+        uses: actions/cache@v2
+        with:
+          path: sdk-main.aar
+          key: diffuse-${{ github.sha }}
   ui-tests:
     name: Android UI Tests
     runs-on: macos-latest
@@ -45,6 +55,7 @@ jobs:
             parallel --retries 3 ::: "./gradlew connectedCheck"
   size-report:
     name: Diffuse report
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,24 @@ jobs:
         git checkout origin/main
         ./gradlew build --stacktrace
         cp sdk/build/outputs/aar/sdk-release.aar sdk-main.aar
-    - name: Diffuse report
-      run: |
-        wget https://github.com/JakeWharton/diffuse/releases/download/0.1.0/diffuse-0.1.0-binary.jar
-        java -jar diffuse-0.1.0-binary.jar diff --aar sdk-main.aar sdk-pr.aar
+    - id: diffuse
+      uses: usefulness/diffuse-action@v1
+      with:
+        old-file-path: sdk-main.aar
+        new-file-path: sdk-pr.aar
+    - uses: peter-evans/find-comment@v1
+      id: find_comment
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body-includes: Diffuse report
+    - uses: peter-evans/create-or-update-comment@v1
+      if: ${{ steps.diffuse.outputs.diff-raw != null || steps.find_comment.outputs.comment-id != null }}
+      with:
+        body: |
+          Diffuse report:
+
+          ${{ steps.diffuse.outputs.diff-gh-comment }}
+        edit-mode: replace
+        comment-id: ${{ steps.find_comment.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -119,3 +119,34 @@ project.afterEvaluate {
         }
     }
 }
+
+long MAX_AAR_SIZE_KB = 200
+
+android.libraryVariants.all { variant ->
+    def variantName = variant.name.capitalize()
+    project.task("report${variantName}AarSize") {
+        group 'Help'
+        description "Report ${variant.name} AAR size"
+        dependsOn variant.packageLibraryProvider
+
+        doFirst {
+            String aarPath = variant.packageLibraryProvider.get().archivePath
+            long aarSizeKb = file(aarPath).length() / 1024
+            println("File ${aarPath} is ${aarSizeKb}Kbyte")
+        }
+    }
+
+    project.tasks.findByName("check").dependsOn(project.task("check${variantName}AarSize") {
+        group 'Verification'
+        description "Checks ${variant.name} AAR size doesn't exceed ${MAX_AAR_SIZE_KB}Kb"
+        dependsOn variant.packageLibraryProvider
+
+        doFirst {
+            String aarPath = variant.packageLibraryProvider.get().archivePath
+            long aarSizeKb = file(aarPath).length() / 1024
+            if (aarSizeKb > MAX_AAR_SIZE_KB) {
+                throw new GradleException("${aarPath} size exceeded! ${aarSizeKb}Kbyte > ${MAX_AAR_SIZE_KB}Kbyte")
+            }
+        }
+    })
+}


### PR DESCRIPTION
 - #33 

### Changelist
 - two gradle tasks added: `report[Debug|Release]AarSize` and `check[Debug|Release]AarSize` (executed on `check`)
 - [Diffuse](https://github.com/JakeWharton/diffuse) to analyze `aar` content was add to CI

### Current AAR

<img width="640" alt="Screen Shot 2022-05-12 at 10 16 08 PM" src="https://user-images.githubusercontent.com/2169738/168163993-7dad3575-0f43-4bb7-9599-22d4ea3b0c4f.png">

Per Android Studio Analyzer:
 - More than half of the size took resources (PNGs)
 - AAR looks really clean
