### PR TITLE
feat: diagnosticLog config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 # 3.3.2
 
-- Add `HCaptchaConfig.diagnosticLog` to enable diagnostics logs that helpful during troubleshooting
+- Add `HCaptchaConfig.diagnosticLog` to log diagnostics that are helpful during troubleshooting
 
 # 3.3.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 3.3.2
+
+- Add `HCaptchaConfig.diagnosticLog` to enable diagnostics logs that helpful during troubleshooting
+
 # 3.3.1
 
 - Fix dialog dismiss crash in specific scenario

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,28 @@
+# Prerequisites software
+
+- Android Studio
+
+# Testing
+
+There is automated testing for every `push` command through github actions (see `.github/workflows/ci.yml`).
+
+You can manually test before pushing by running both unit tests and instrumented tests:
+* ```gradlew test```
+* ```gradlew connectedDebugAndroidTest```
+
+# Publishing
+
+To publish a new version follow the next steps:
+
+1. Bump versions in the [`sdk/build.gradle`](./sdk/build.gradle) file:
+   * `android.defaultConfig.versionCode`: increment by **1** (next integer)
+   * `android.defaultConfig.versionName`: [Semantic Versioning](https://semver.org)
+2. Update [`CHANGELOG.md`](./CHANGELOG.md) with changes since last version
+3. Create a [Github Release](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/managing-releases-in-a-repository#creating-a-release) with the **SAME** version from step 1 (**without** a prefix such as `v`)
+   * JitPack's automatic process will be triggered upon first installation of the new package version
+
+# Known issues
+
+### Android Studio Lombok plugin doesn't work (generated methods not found)
+
+Install lombok plugin from https://github.com/mplushnikov/lombok-intellij-plugin/issues/1130#issuecomment-1108316265

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The following list contains configuration properties to allows customization of 
 | `loading`         | Boolean                 | No       | True      | Show or hide the loading dialog.                                                                                                                                     |
 | `hideDialog`      | Boolean                 | No       | False     | To be used in combination with a passive sitekey when no user interaction is required. See Enterprise docs.                                                          |
 | `tokenExpiration` | long                    | No       | 120       | hCaptcha token expiration timeout (seconds).                                                                                                                         |
+| `diagnosticLog`   | Boolean                 | No       | False     | Enable diagnostics logs that helpful during troubleshooting                                                                                                          |
 
 ### Config Examples
 
@@ -188,6 +189,7 @@ The following is a list of possible error codes:
 
 Useful error messages are often rendered on the hCaptcha checkbox. For example, if the sitekey within your config is invalid, you'll see a message there. To quickly debug your local instance using this tool, set `.size(HCaptchaSize.NORMAL)`
 
+`HCaptchaConfigBuilder.diagnosticLog(true)` can help to get more detailed logs.
 
 ### Verify the completed challenge
 

--- a/README.md
+++ b/README.md
@@ -199,19 +199,4 @@ After retrieving a `token`, you should pass it to your backend in order to verif
 
 ## For maintainers
 
-To see available gradle tasks run: `gradlew tasks`.
-
-### Testing
-There is automated testing for every `push` command through github actions (see `.github/workflows/ci.yml`).
-
-You can manually test before pushing by running both unit tests and instrumented tests:
-* ```gradlew test```
-* ```gradlew connectedDebugAndroidTest```
-
-### Publishing
-To publish a new version follow the next steps:
-1. Bump versions in the `sdk/build.gradle` file:
-   * `android.defaultConfig.versionCode`: increment by **1** (next integer)
-   * `android.defaultConfig.versionName`: [Semantic Versioning](https://semver.org)
-2. Create a [Github Release](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/managing-releases-in-a-repository#creating-a-release) with the **SAME** version from step 1 (**without** a prefix such as `v`)
-   * JitPack's automatic process will be triggered upon first installation of the new package version
+Check [MAINTAINERS.md](./MAINTAINERS.md)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The following list contains configuration properties to allows customization of 
 | `loading`         | Boolean                 | No       | True      | Show or hide the loading dialog.                                                                                                                                     |
 | `hideDialog`      | Boolean                 | No       | False     | To be used in combination with a passive sitekey when no user interaction is required. See Enterprise docs.                                                          |
 | `tokenExpiration` | long                    | No       | 120       | hCaptcha token expiration timeout (seconds).                                                                                                                         |
-| `diagnosticLog`   | Boolean                 | No       | False     | Enable diagnostics logs that helpful during troubleshooting                                                                                                          |
+| `diagnosticLog`   | Boolean                 | No       | False     | Emit detailed console logs for debugging                                                                                                          |
 
 ### Config Examples
 
@@ -199,4 +199,4 @@ After retrieving a `token`, you should pass it to your backend in order to verif
 
 ## For maintainers
 
-Check [MAINTAINERS.md](./MAINTAINERS.md)
+If you plan to contribute to the repo, please see [MAINTAINERS.md](./MAINTAINERS.md) for detailed build, test, and release instructions.

--- a/example-app/src/main/java/com/hcaptcha/example/MainActivity.java
+++ b/example-app/src/main/java/com/hcaptcha/example/MainActivity.java
@@ -67,6 +67,7 @@ public class MainActivity extends AppCompatActivity {
                 .loading(loading.isChecked())
                 .hideDialog(hideDialog.isChecked())
                 .tokenExpiration(10)
+                .diagnosticLog(true)
                 .build();
     }
 

--- a/gradle/config/checkstyle.xml
+++ b/gradle/config/checkstyle.xml
@@ -57,7 +57,7 @@ Description: https://source.android.com/source/code-style.html
     <module name="MethodName">
       <property name="format" value="^[a-z][a-z0-9]?[a-zA-Z0-9_]*$"/>
       <message key="name.invalidPattern"
-               value="Method name ''{0}'' must be at least one characters long."/>
+               value="Method name ''{0}'' must be at least one character long."/>
     </module>
 
     <!-- Require parameter names to be at least two characters long -->

--- a/gradle/config/checkstyle.xml
+++ b/gradle/config/checkstyle.xml
@@ -55,9 +55,9 @@ Description: https://source.android.com/source/code-style.html
     lower case letter.
     -->
     <module name="MethodName">
-      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+      <property name="format" value="^[a-z][a-z0-9]?[a-zA-Z0-9_]*$"/>
       <message key="name.invalidPattern"
-               value="Method name ''{0}'' must be at least two characters long."/>
+               value="Method name ''{0}'' must be at least one characters long."/>
     </module>
 
     <!-- Require parameter names to be at least two characters long -->

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -19,11 +19,11 @@ android {
         // See https://developer.android.com/studio/publish/versioning
         // versionCode must be integer and be incremented by one for every new update
         // android system uses this to prevent downgrades
-        versionCode 19
+        versionCode 20
 
         // version number visible to the user
         // should follow semantic versioning (See https://semver.org)
-        versionName "3.3.1"
+        versionName "3.3.2"
 
         buildConfigField 'String', 'VERSION_NAME', "\"${defaultConfig.versionName}_${defaultConfig.versionCode}\""
 

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptcha.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptcha.java
@@ -66,6 +66,9 @@ public final class HCaptcha extends Task<HCaptchaTokenResponse> implements IHCap
 
     @Override
     public HCaptcha setup(@NonNull final HCaptchaConfig inputConfig) {
+        HCaptchaLog.sDiagnosticsLogEnabled = inputConfig.getDiagnosticLog();
+        HCaptchaLog.d("HCaptcha.setup");
+
         final HCaptchaStateListener listener = new HCaptchaStateListener() {
             @Override
             void onOpen() {
@@ -74,12 +77,14 @@ public final class HCaptcha extends Task<HCaptchaTokenResponse> implements IHCap
 
             @Override
             void onSuccess(final String token) {
+                HCaptchaLog.d("HCaptcha.onSuccess");
                 scheduleCaptchaExpired(HCaptcha.this.config.getTokenExpiration());
                 setResult(new HCaptchaTokenResponse(token, HCaptcha.this.handler));
             }
 
             @Override
             void onFailure(final HCaptchaException exception) {
+                HCaptchaLog.d("HCaptcha.onFailure");
                 setException(exception);
             }
         };
@@ -130,6 +135,7 @@ public final class HCaptcha extends Task<HCaptchaTokenResponse> implements IHCap
     }
 
     private HCaptcha startVerification() {
+        HCaptchaLog.d("HCaptcha.startVerification");
         handler.removeCallbacksAndMessages(null);
         assert captchaVerifier != null;
         captchaVerifier.startVerification(activity);

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaConfig.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaConfig.java
@@ -119,4 +119,10 @@ public class HCaptchaConfig implements Serializable {
      */
     @Builder.Default
     private long tokenExpiration = 120;
+
+    /**
+     * Enable diagnostics logs that helpful during troubleshooting
+     */
+    @Builder.Default
+    private Boolean diagnosticLog = false;
 }

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaDialogFragment.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaDialogFragment.java
@@ -10,7 +10,6 @@ import android.os.BadParcelableException;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -67,6 +66,7 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
             @NonNull final HCaptchaStateListener listener,
             @NonNull final IHCaptchaHtmlProvider htmlProvider
     ) {
+        HCaptchaLog.d("DialogFragment.newInstance");
         final Bundle args = new Bundle();
         args.putSerializable(KEY_CONFIG, config);
         args.putParcelable(KEY_LISTENER, listener);
@@ -84,7 +84,9 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        HCaptchaLog.d("DialogFragment.onCreateView");
         final View rootView = inflater.inflate(R.layout.hcaptcha_fragment, container, false);
+        HCaptchaLog.d("DialogFragment.onCreateView inflated");
         assert getArguments() != null;
         final HCaptchaStateListener listener;
         final IHCaptchaHtmlProvider htmlProvider;
@@ -94,6 +96,7 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
             htmlProvider = (IHCaptchaHtmlProvider) getArguments().getSerializable(KEY_HTML);
             assert htmlProvider != null;
         } catch (BadParcelableException | ClassCastException e) {
+            HCaptchaLog.w("Cannot process getArguments(). Dismissing dialog...");
             // Happens when fragment tries to reconstruct because the activity was killed
             // And thus there is no way of communicating back
             dismiss();
@@ -111,6 +114,7 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
 
     @Override
     public void onDestroy() {
+        HCaptchaLog.d("DialogFragment.onDestroy");
         super.onDestroy();
         if (webViewHelper != null) {
             webViewHelper.destroy();
@@ -119,6 +123,7 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
 
     @Override
     public void onStart() {
+        HCaptchaLog.d("DialogFragment.onStart");
         super.onStart();
         assert webViewHelper != null;
         final Dialog dialog = getDialog();
@@ -135,6 +140,7 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
 
     @Override
     public void onCancel(@NonNull DialogInterface dialogInterface) {
+        HCaptchaLog.d("DialogFragment.onCancel");
         // User canceled the dialog through either `back` button or an outside touch
         super.onCancel(dialogInterface);
         this.onFailure(new HCaptchaException(HCaptchaError.CHALLENGE_CLOSED));
@@ -197,7 +203,7 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
         final FragmentManager fragmentManager = fragmentActivity.getSupportFragmentManager();
         final Fragment oldFragment = fragmentManager.findFragmentByTag(HCaptchaDialogFragment.TAG);
         if (oldFragment != null && oldFragment.isAdded()) {
-            Log.w(TAG, "Skip. HCaptchaDialogFragment was already added.");
+            HCaptchaLog.w("DialogFragment was already added.");
             return;
         }
         show(fragmentManager, HCaptchaDialogFragment.TAG);

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaHeadlessWebView.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaHeadlessWebView.java
@@ -28,6 +28,7 @@ final class HCaptchaHeadlessWebView implements IHCaptchaVerifier {
                             @NonNull final HCaptchaConfig config,
                             @NonNull final HCaptchaStateListener listener,
                             @NonNull final IHCaptchaHtmlProvider htmlProvider) {
+        HCaptchaLog.d("HeadlessWebView.init");
         this.config = config;
         this.listener = listener;
         final WebView webView = new WebView(activity);

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaJSInterface.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaJSInterface.java
@@ -35,6 +35,7 @@ class HCaptchaJSInterface implements Serializable {
 
     @JavascriptInterface
     public void onPass(final String token) {
+        HCaptchaLog.d("JSInterface.onPass");
         handler.post(new Runnable() {
             @Override
             public void run() {
@@ -45,6 +46,7 @@ class HCaptchaJSInterface implements Serializable {
 
     @JavascriptInterface
     public void onError(final int errCode) {
+        HCaptchaLog.d("JSInterface.onError %d", errCode);
         final HCaptchaError error = HCaptchaError.fromId(errCode);
         handler.post(new Runnable() {
             @Override
@@ -56,6 +58,7 @@ class HCaptchaJSInterface implements Serializable {
 
     @JavascriptInterface
     public void onLoaded() {
+        HCaptchaLog.d("JSInterface.onLoaded");
         handler.post(new Runnable() {
             @Override
             public void run() {
@@ -66,6 +69,7 @@ class HCaptchaJSInterface implements Serializable {
 
     @JavascriptInterface
     public void onOpen() {
+        HCaptchaLog.d("JSInterface.onOpen");
         handler.post(new Runnable() {
             @Override
             public void run() {

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaLog.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaLog.java
@@ -1,0 +1,33 @@
+package com.hcaptcha.sdk;
+
+import android.util.Log;
+
+import java.util.Locale;
+
+/**
+ * Logger
+ */
+public final class HCaptchaLog {
+    private static final String TAG = "hcaptcha";
+
+    static boolean sDiagnosticsLogEnabled = false;
+
+    private HCaptchaLog() {
+    }
+
+    public static void w(String message) {
+        Log.w(TAG, message);
+    }
+
+    public static void d(String message) {
+        if (sDiagnosticsLogEnabled) {
+            Log.d(TAG, message);
+        }
+    }
+
+    public static void d(String message, Object... args) {
+        if (sDiagnosticsLogEnabled) {
+            Log.d(TAG, String.format(Locale.getDefault(), message, args));
+        }
+    }
+}

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaWebViewHelper.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaWebViewHelper.java
@@ -2,14 +2,16 @@ package com.hcaptcha.sdk;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.webkit.ConsoleMessage;
+import android.webkit.WebChromeClient;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebSettings;
@@ -65,6 +67,8 @@ final class HCaptchaWebViewHelper {
      */
     @SuppressLint({"SetJavaScriptEnabled", "AddJavascriptInterface"})
     private void setupWebView(@NonNull final Handler handler) {
+        HCaptchaLog.d("WebViewHelper.setupWebView");
+
         final HCaptchaJSInterface jsInterface = new HCaptchaJSInterface(handler, config, captchaVerifier);
         final HCaptchaDebugInfo debugInfo = new HCaptchaDebugInfo(context);
         final WebSettings settings = webView.getSettings();
@@ -77,27 +81,37 @@ final class HCaptchaWebViewHelper {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             webView.setWebViewClient(new HCaptchaWebClient());
         }
+        if (HCaptchaLog.sDiagnosticsLogEnabled) {
+            webView.setWebChromeClient(new HCaptchaWebChromeClient());
+        }
         webView.setBackgroundColor(Color.TRANSPARENT);
         webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
         webView.addJavascriptInterface(jsInterface, HCaptchaJSInterface.JS_INTERFACE_TAG);
         webView.addJavascriptInterface(debugInfo, HCaptchaDebugInfo.JS_INTERFACE_TAG);
         webView.loadDataWithBaseURL(config.getHost(), htmlProvider.getHtml(), "text/html", "UTF-8", null);
+        HCaptchaLog.d("WebViewHelper.loadData");
     }
 
     public void destroy() {
+        HCaptchaLog.d("WebViewHelper.destroy");
+
         webView.removeJavascriptInterface(HCaptchaJSInterface.JS_INTERFACE_TAG);
         webView.removeJavascriptInterface(HCaptchaDebugInfo.JS_INTERFACE_TAG);
         final ViewParent parent = webView.getParent();
         if (parent instanceof ViewGroup) {
             ((ViewGroup) parent).removeView(webView);
         } else {
-            Log.w(HCaptcha.TAG, "webView.getParent() is null or not a ViewGroup instance");
+            HCaptchaLog.w("webView.getParent() is null or not a ViewGroup instance");
         }
         webView.destroy();
     }
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-    private class HCaptchaWebClient  extends WebViewClient {
+    private class HCaptchaWebClient extends WebViewClient {
+
+        private String stripUrl(String url) {
+            return url.split("[?#]")[0] + "...";
+        }
 
         @Override
         public WebResourceResponse shouldInterceptRequest (final WebView view, final WebResourceRequest request) {
@@ -107,6 +121,40 @@ final class HCaptchaWebViewHelper {
                 webView.removeJavascriptInterface(HCaptchaDebugInfo.JS_INTERFACE_TAG);
             }
             return super.shouldInterceptRequest(view, request);
+        }
+
+        @Override
+        public void onPageStarted(WebView view, String url, Bitmap favicon) {
+            HCaptchaLog.d("[webview] onPageStarted " + stripUrl(url));
+        }
+
+        @Override
+        public void onLoadResource(WebView view, String url) {
+            HCaptchaLog.d("[webview] onLoadResource " + stripUrl(url));
+        }
+
+        @Override
+        public void onPageFinished(WebView view, String url) {
+            HCaptchaLog.d("[webview] onPageFinished " + stripUrl(url));
+        }
+
+        @Override
+        public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
+            super.onReceivedError(view, errorCode, description, failingUrl);
+            HCaptchaLog.d("[webview] onReceivedError \"%s\" (%d)", description, errorCode);
+        }
+    }
+
+    private static class HCaptchaWebChromeClient extends WebChromeClient {
+        @Override
+        public boolean onConsoleMessage(ConsoleMessage consoleMessage) {
+            HCaptchaLog.d("[webview] onConsoleMessage " + consoleMessage.message());
+            return true;
+        }
+
+        @Override
+        public void onProgressChanged(WebView view, int newProgress) {
+            HCaptchaLog.d("[webview] onProgressChanged %d%%", newProgress);
         }
     }
 }

--- a/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaJSInterfaceTest.java
+++ b/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaJSInterfaceTest.java
@@ -80,6 +80,7 @@ public class HCaptchaJSInterfaceTest {
                 .resetOnTimeout(true)
                 .hideDialog(true)
                 .tokenExpiration(timeout)
+                .diagnosticLog(true)
                 .build();
         final HCaptchaJSInterface jsInterface = new HCaptchaJSInterface(handler, config, captchaVerifier);
 
@@ -101,6 +102,7 @@ public class HCaptchaJSInterfaceTest {
         expected.put("resetOnTimeout", true);
         expected.put("hideDialog", true);
         expected.put("tokenExpiration", timeout);
+        expected.put("diagnosticLog", true);
 
         JSONAssert.assertEquals(jsInterface.getConfig(), expected, false);
     }
@@ -139,6 +141,7 @@ public class HCaptchaJSInterfaceTest {
         expected.put("resetOnTimeout", false);
         expected.put("hideDialog", false);
         expected.put("tokenExpiration", defaultTimeout);
+        expected.put("diagnosticLog", false);
 
         JSONAssert.assertEquals(jsInterface.getConfig(), expected, false);
     }


### PR DESCRIPTION
 - The idea of this PR is to simplify troubleshooting performance issues on the client side
 - SDK add new `diagnosticLog` property in `HCaptchaConfig` which enables extra logging
 - All potentially sensitive info is removed (i.e. GET params in webview requests)

TODO:
- [x] add changelog
- [x] extend readme with the new config