### PR TITLE
fix: webview crash on "onCheckIsTextEditor" call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [16, 29]
-        target: [default] #, google_apis]
+        include:
+          - api-level: 29
+            target: default
+          - api-level: 16
+            arch: armeabi-v7a
+            target: default
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - api-level: 29
-            target: default
-          - api-level: 16
-            arch: armeabi-v7a
-            target: default
+        api-level: [29] # , 23, 21]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [29] # , 23, 21]
+        target: [default] #, google_apis]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [29] # , 23, 21]
+        api-level: [16, 29]
         target: [default] #, google_apis]
     steps:
       - uses: actions/checkout@v2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 3.3.3
+
+- Fix Android 10 WebView crash on onCheckIsTextEditor call
+
 # 3.3.2
 
 - Add `HCaptchaConfig.diagnosticLog` to log diagnostics that are helpful during troubleshooting

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -19,11 +19,11 @@ android {
         // See https://developer.android.com/studio/publish/versioning
         // versionCode must be integer and be incremented by one for every new update
         // android system uses this to prevent downgrades
-        versionCode 20
+        versionCode 21
 
         // version number visible to the user
         // should follow semantic versioning (See https://semver.org)
-        versionName "3.3.2"
+        versionName "3.3.3"
 
         buildConfigField 'String', 'VERSION_NAME', "\"${defaultConfig.versionName}_${defaultConfig.versionCode}\""
 

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaHeadlessWebView.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaHeadlessWebView.java
@@ -30,7 +30,7 @@ final class HCaptchaHeadlessWebView implements IHCaptchaVerifier {
                             @NonNull final IHCaptchaHtmlProvider htmlProvider) {
         this.config = config;
         this.listener = listener;
-        final WebView webView = new WebView(activity);
+        final WebView webView = new HCaptchaWebView(activity);
         webView.setId(R.id.webView);
         webView.setVisibility(View.GONE);
         if (webView.getParent() == null) {

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaWebView.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaWebView.java
@@ -1,0 +1,44 @@
+package com.hcaptcha.sdk;
+
+import android.content.Context;
+import android.os.Build;
+import android.os.Looper;
+import android.util.AttributeSet;
+import android.webkit.WebView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+public class HCaptchaWebView extends WebView {
+    public HCaptchaWebView(@NonNull Context context) {
+        super(context);
+    }
+
+    public HCaptchaWebView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public HCaptchaWebView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    public HCaptchaWebView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    /**
+     * Workaround for crash in WebViewChromium
+     * Details:
+     *  - https://stackoverflow.com/questions/58519749
+     *  - https://github.com/zulip/zulip-mobile/issues/4051#issuecomment-616855833
+     */
+    @Override
+    public boolean onCheckIsTextEditor() {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            return super.onCheckIsTextEditor();
+        } else {
+            return false;
+        }
+    }
+}

--- a/sdk/src/main/res/layout/hcaptcha_fragment.xml
+++ b/sdk/src/main/res/layout/hcaptcha_fragment.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <WebView
+    <com.hcaptcha.sdk.HCaptchaWebView
         android:id="@+id/webView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />


### PR DESCRIPTION


java.lang.RuntimeException: Probable deadlock detected due to WebView API being called on incorrect thread while the UI thread is blocked