### PR TITLE
fi(ci): warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     name: Build & Unit-test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: adopt
@@ -31,7 +31,7 @@ jobs:
       - name: JitPack Test
         run: ./gradlew publishReleasePublicationToMavenLocal
       - if: github.event_name == 'push'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: sdk-main.aar
           key: diffuse-${{ github.sha }}
@@ -42,12 +42,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: adopt
           cache: 'gradle'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
@@ -65,8 +65,8 @@ jobs:
         api-level: [29] # , 23, 21]
         target: [default] #, google_apis]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: adopt
@@ -88,7 +88,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: adopt
@@ -105,12 +105,12 @@ jobs:
       with:
         old-file-path: sdk-main.aar
         new-file-path: sdk-pr.aar
-    - uses: peter-evans/find-comment@v1
+    - uses: peter-evans/find-comment@v2
       id: find_comment
       with:
         issue-number: ${{ github.event.pull_request.number }}
         body-includes: Diffuse report
-    - uses: peter-evans/create-or-update-comment@v1
+    - uses: peter-evans/create-or-update-comment@v2
       if: ${{ steps.diffuse.outputs.diff-raw != null || steps.find_comment.outputs.comment-id != null }}
       with:
         body: |
@@ -139,8 +139,8 @@ jobs:
             target: 30
             appcompat: 1.3.1
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: adopt

--- a/build.gradle
+++ b/build.gradle
@@ -18,3 +18,15 @@ allprojects {
         mavenCentral()
     }
 }
+
+gradle.afterProject {
+    def hookScript = new File(rootProject.rootDir, ".git/hooks/pre-commit")
+
+    if (!hookScript.exists()) {
+        hookScript.text = """\
+                          #!/bin/sh
+                          ./gradlew check
+                          """.stripIndent()
+        hookScript.setExecutable(true)
+    }
+}


### PR DESCRIPTION
 - Upgrade actions to the latest version (it fixes warning about deprecated set-output command)
 - Added pre-commit hook setup to gradle