### PR TITLE
build(deps): upgrade gradle to 7.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: adopt
           cache: 'gradle'
       - name: Assemble & Test
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: adopt
           cache: 'gradle'
       - uses: reactivecircus/android-emulator-runner@v2
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: adopt
           cache: 'gradle'
       - uses: reactivecircus/android-emulator-runner@v2
@@ -144,6 +144,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - compile: 33
+            target: 33
+            appcompat: 1.5.1
           - compile: 32
             target: 32
             appcompat: 1.4.2
@@ -157,7 +160,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: adopt
           cache: 'gradle'
       - run: |

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.5.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.benchmark:benchmark-junit4:1.2.0-alpha07'
+    androidTestImplementation 'androidx.benchmark:benchmark-junit4:1.1.1'
 
     implementation project(path: ':sdk')
     implementation 'androidx.appcompat:appcompat:1.5.1'

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -4,7 +4,8 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
+    namespace 'com.hcaptcha.sdk.bench'
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -13,7 +14,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 32
+        targetSdkVersion 33
 
         testInstrumentationRunner 'androidx.benchmark.junit4.AndroidBenchmarkRunner'
         testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "DEBUGGABLE,EMULATOR,LOW-BATTERY,UNLOCKED"
@@ -38,7 +39,7 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.5.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.benchmark:benchmark-junit4:1.1.1'
+    androidTestImplementation 'androidx.benchmark:benchmark-junit4:1.2.0-alpha07'
 
     implementation project(path: ':sdk')
     implementation 'androidx.appcompat:appcompat:1.5.1'

--- a/benchmark/src/androidTest/AndroidManifest.xml
+++ b/benchmark/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.hcaptcha.sdk.bench">
+    xmlns:tools="http://schemas.android.com/tools" >
 
     <!--
       Important: disable debugging for accurate performance results
@@ -10,9 +9,7 @@
       manifest, as it is not possible to override this flag from Gradle.
     -->
     <application
-        android:debuggable="false"
-        tools:ignore="HardcodedDebugMode"
-        tools:replace="android:debuggable">
+        tools:ignore="HardcodedDebugMode">
         <activity android:name="com.hcaptcha.sdk.TestActivity" android:theme="@style/Theme.AppCompat.Light" />
     </application>
 </manifest>

--- a/benchmark/src/main/AndroidManifest.xml
+++ b/benchmark/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.hcaptcha.sdk.bench" />
+<manifest />

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath 'androidx.benchmark:benchmark-gradle-plugin:1.1.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'androidx.benchmark:benchmark-gradle-plugin:1.2.0-alpha07'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         classpath 'androidx.benchmark:benchmark-gradle-plugin:1.1.1'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath 'androidx.benchmark:benchmark-gradle-plugin:1.2.0-alpha07'
+        classpath 'androidx.benchmark:benchmark-gradle-plugin:1.1.1'
     }
 }
 

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -11,6 +11,7 @@ def prop(name, fallback) {
 android {
     compileSdkVersion intProp("exampleCompileSdkVersion", 32)
     buildToolsVersion "30.0.3"
+    namespace 'com.hcaptcha.example'
 
     defaultConfig {
         applicationId "com.hcaptcha.example"
@@ -33,6 +34,10 @@ android {
         release {
             minifyEnabled true
         }
+    }
+
+    lint {
+        disable 'UsingOnClickInXml'
     }
 }
 

--- a/example-app/src/main/AndroidManifest.xml
+++ b/example-app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.hcaptcha.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,5 @@ org.gradle.jvmargs=-Xmx2048m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+# Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0
+android.disableAutomaticComponentCreation=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,4 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 # Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0
-android.disableAutomaticComponentCreation=false
+android.disableAutomaticComponentCreation=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -83,20 +83,6 @@ dependencies {
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
 }
 
-task androidJavadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    android.libraryVariants.all { variant ->
-        owner.classpath += variant.javaCompileProvider.get().classpath
-    }
-    exclude '**/R.html', '**/R.*.html', '**/index.html'
-}
-
-task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-    archiveClassifier.set('javadoc')
-    from androidJavadocs.destinationDir
-}
-
 project.afterEvaluate {
     publishing {
         repositories {
@@ -105,9 +91,6 @@ project.afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
-
-                // Adds javadocs
-                artifact androidJavadocsJar
 
                 groupId = 'com.hcaptcha'
                 artifactId = 'sdk'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -174,6 +174,10 @@ android.libraryVariants.all { variant ->
     })
 }
 
+checkstyle {
+    toolVersion = '8.45.1'
+}
+
 task checkstyle(type: Checkstyle) {
     description 'Check code standard'
     group 'verification'
@@ -199,9 +203,9 @@ task pmd(type: Pmd) {
     include '**/*.java'
     exclude '**/gen/**'
     reports {
-        xml.enabled = false
-        html.enabled = true
-        html.destination = file("$project.buildDir/outputs/pmd/pmd.html")
+        xml.required = false
+        html.required = true
+        html.outputLocation = file("$project.buildDir/outputs/pmd/pmd.html")
     }
 }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -9,12 +9,13 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     buildToolsVersion "30.0.3"
+    namespace 'com.hcaptcha.sdk'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 32
+        targetSdkVersion 33
 
         // See https://developer.android.com/studio/publish/versioning
         // versionCode must be integer and be incremented by one for every new update

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -48,6 +48,13 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
+
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 dependencies {

--- a/sdk/src/androidTest/AndroidManifest.xml
+++ b/sdk/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.hcaptcha.sdk"
     tools:ignore="ExtraText">
     <application>
         <activity android:name=".TestActivity" android:theme="@style/Theme.AppCompat.Light" />

--- a/sdk/src/androidTest/AndroidManifest.xml
+++ b/sdk/src/androidTest/AndroidManifest.xml
@@ -2,6 +2,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="ExtraText">
     <application>
-        <activity android:name=".TestActivity" android:theme="@style/Theme.AppCompat.Light" />
+        <activity android:name="com.hcaptcha.sdk.TestActivity" android:theme="@style/Theme.AppCompat.Light" />
     </application>
 </manifest>

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.hcaptcha.sdk">
+    xmlns:tools="http://schemas.android.com/tools">
     <application android:usesCleartextTraffic="false" tools:targetApi="n" />
 </manifest>


### PR DESCRIPTION
### Intro/Problem

Benchmark tests don't run stable on the old `com.android.tools.build:gradle` plugin (` < 4.1.3`). But it works really stable for the new version of the plugin (9 of 9 runs were successful)

### Proposed solution

I propose updating it because sooner or later we will need to update it anyway.

### Side effects

- Android studio needs to be updated to 2022.2.1 (More details about compatibility here https://developer.android.com/studio/releases#android_gradle_plugin_and_android_studio_compatibility)

- This change should not affect end users. I have compared the last aar from jitpack https://jitpack.io/com/github/hCaptcha/hcaptcha-android-sdk/3.3.5/hcaptcha-android-sdk-3.3.5.aar and `sdk/build/outputs/aar/sdk-release.aar` not significant difference observed