### PR TITLE
feat(ci): cache emulators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,10 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+
 jobs:
-  build:
-    name: 'Build & Unit-test'
+  test:
+    name: 'Test Unit'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,10 +24,10 @@ jobs:
           java-version: '11'
           distribution: adopt
       - uses: gradle/gradle-build-action@v2
-      - name: 'Assemble & Test'
-        run: |
-          ./gradlew build --stacktrace
-          cp sdk/build/outputs/aar/sdk-release.aar sdk-main.aar
+        with:
+          cache-read-only: false
+      - name: 'Build'
+        run: ./gradlew build --stacktrace
       - name: 'HTML ES5 test'
         run: |
           npm install -g jshint
@@ -34,43 +35,50 @@ jobs:
           jshint --extract=always sdk/build/hcaptcha-form.html
       - name: 'JitPack Test'
         run: ./gradlew publishReleasePublicationToMavenLocal
-      - if: github.event_name == 'push'
-        uses: actions/cache@v3
-        with:
-          path: sdk-main.aar
-          key: diffuse-${{ github.sha }}
 
-  sonar:
-    if: false
-    name: 'Sonar'
+  build-matrix:
+    name: 'Build (target:${{ matrix.target }} compile:${{ matrix.compile }} appcompat: ${{ matrix.appcompat }})'
+    needs: [ test ]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - compile: 33
+            target: 33
+            appcompat: 1.5.1
+          - compile: 32
+            target: 32
+            appcompat: 1.4.2
+          - compile: 32
+            target: 30
+            appcompat: 1.3.1
+          - compile: 30
+            target: 30
+            appcompat: 1.3.1
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: adopt
       - uses: gradle/gradle-build-action@v2
-      - uses: actions/cache@v3
         with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonarqube --info
+          cache-read-only: false
+      - run: |
+          ./gradlew build -PexampleCompileSdkVersion=${{ matrix.compile }} \
+                          -PexampleTargetSdkVersion=${{ matrix.target }} \
+                          -PexampleAppcompatVersion=${{ matrix.appcompat }}
 
-  ui-tests:
-    name: 'Android UI Tests'
+
+  test-ui:
+    name: 'Test UI'
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        api-level: [29] # , 23, 21]
-        target: [default] #, google_apis]
+        api-level: [29]
+        target: [default]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -78,6 +86,8 @@ jobs:
           java-version: '11'
           distribution: adopt
       - uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: 'Cache AVD'
         uses: actions/cache@v3
         id: avd-cache
@@ -117,15 +127,14 @@ jobs:
           name: androidTest-results
           path: sdk/build/outputs/androidTest-results
 
-  benchmark-tests:
-    if: false
-    name: 'Android Benchmark'
+  test-benchmark:
+    name: 'Test Benchmark'
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        api-level: [29] # , 23, 21]
-        target: [default] #, google_apis]
+        api-level: [29]
+        target: [default]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -133,26 +142,70 @@ jobs:
           java-version: '11'
           distribution: adopt
       - uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
+      - name: 'Cache AVD'
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-api-${{ matrix.api-level }}-target-${{ matrix.target }}
+      - name: 'Create AVD'
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          force-avd-creation: false
+          disable-animations: false
+          arch: x86_64
+          profile: Nexus 6
+          script: echo "Generated AVD snapshot for caching."
       - uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          force-avd-creation: false
+          disable-animations: true
           arch: x86_64
           profile: Nexus 6
-          script: |
-            # https://developer.android.com/topic/performance/benchmarking/benchmarking-in-ci#clock-locking
-            adb root
-            ./gradlew lockClocks || true
-            # NOTE bench:connectedCheck and bench:connectedAndroidTest leaves connected_android_test_additional_output empty
-            ./gradlew --no-daemon --no-parallel bench:connectedReleaseAndroidTest --debug
+          script: ./gradlew --no-daemon --no-parallel bench:connectedReleaseAndroidTest --debug
       - uses: actions/upload-artifact@v3
         with:
           name: benchmark-json-output
           path: benchmark/build/outputs/connected_android_test_additional_output
 
+  sonar:
+    name: 'Sonar'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: adopt
+      - uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
+      - uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonarqube --info
+
   size-report:
     name: 'Diffuse report'
-    if: false && github.event_name == 'pull_request'
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -163,10 +216,14 @@ jobs:
         java-version: '11'
         distribution: adopt
     - uses: gradle/gradle-build-action@v2
-    - name: 'Build sdk for PR and main branch'
+      with:
+        cache-read-only: false
+    - name: 'Build'
       run: |
         ./gradlew build --stacktrace
         cp sdk/build/outputs/aar/sdk-release.aar sdk-pr.aar
+    - name: 'Build main'
+      run: |
         git checkout origin/main
         ./gradlew build --stacktrace
         cp sdk/build/outputs/aar/sdk-release.aar sdk-main.aar
@@ -191,35 +248,3 @@ jobs:
         comment-id: ${{ steps.find_comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         token: ${{ secrets.GITHUB_TOKEN }}
-
-  sdk-compile-test:
-    name: 'Compile target:${{ matrix.target }} compile:${{ matrix.compile }} appcompat: ${{ matrix.appcompat }}'
-    needs: [build]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - compile: 33
-            target: 33
-            appcompat: 1.5.1
-          - compile: 32
-            target: 32
-            appcompat: 1.4.2
-          - compile: 32
-            target: 30
-            appcompat: 1.3.1
-          - compile: 30
-            target: 30
-            appcompat: 1.3.1
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: adopt
-      - uses: gradle/gradle-build-action@v2
-      - run: |
-          ./gradlew build -PexampleCompileSdkVersion=${{ matrix.compile }} \
-                          -PexampleTargetSdkVersion=${{ matrix.target }} \
-                          -PexampleAppcompatVersion=${{ matrix.appcompat }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
           disable-animations: true
           arch: x86_64
           profile: Nexus 6
-          script: ./gradlew --no-daemon --no-parallel bench:connectedReleaseAndroidTest --debug
+          script: ./gradlew bench:connectedReleaseAndroidTest
       - uses: actions/upload-artifact@v3
         with:
           name: benchmark-json-output
@@ -181,6 +181,7 @@ jobs:
 
   sonar:
     name: 'Sonar'
+    needs: [ test ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -205,6 +206,7 @@ jobs:
 
   size-report:
     name: 'Diffuse report'
+    needs: [ test ]
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           key: diffuse-${{ github.sha }}
 
   sonar:
+    if: false
     name: 'Sonar'
     runs-on: ubuntu-latest
     steps:
@@ -77,29 +78,33 @@ jobs:
           java-version: '11'
           distribution: adopt
       - uses: gradle/gradle-build-action@v2
-      - name: 'AVD cache'
+      - name: 'Cache AVD'
         uses: actions/cache@v3
         id: avd-cache
         with:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
-      - name: 'Create AVD and generate snapshot for caching'
+          key: avd-api-${{ matrix.api-level }}-target-${{ matrix.target }}
+      - name: 'Create AVD'
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          force-avd-creation: false
+          target: ${{ matrix.target }}
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          force-avd-creation: false
           disable-animations: false
+          arch: x86_64
+          profile: Nexus 6
           script: echo "Generated AVD snapshot for caching."
-      - uses: reactivecircus/android-emulator-runner@v2
+      - name: 'Tests'
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
-          force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          force-avd-creation: false
           disable-animations: true
           arch: x86_64
           profile: Nexus 6
@@ -113,6 +118,7 @@ jobs:
           path: sdk/build/outputs/androidTest-results
 
   benchmark-tests:
+    if: false
     name: 'Android Benchmark'
     runs-on: macos-latest
     strategy:
@@ -146,7 +152,7 @@ jobs:
 
   size-report:
     name: 'Diffuse report'
-    if: github.event_name == 'pull_request'
+    if: false && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci
+name: 'ci'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,7 +14,7 @@ on:
       - '**.md'
 jobs:
   build:
-    name: Build & Unit-test
+    name: 'Build & Unit-test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,24 +23,25 @@ jobs:
           java-version: '11'
           distribution: adopt
           cache: 'gradle'
-      - name: Assemble & Test
+      - name: 'Assemble & Test'
         run: |
           ./gradlew build --stacktrace
           cp sdk/build/outputs/aar/sdk-release.aar sdk-main.aar
-      - name: HTML ES5 test
+      - name: 'HTML ES5 test'
         run: |
           npm install -g jshint
           java -cp sdk/build/intermediates/javac/release/classes com.hcaptcha.sdk.HCaptchaHtml > sdk/build/hcaptcha-form.html
           jshint --extract=always sdk/build/hcaptcha-form.html
-      - name: JitPack Test
+      - name: 'JitPack Test'
         run: ./gradlew publishReleasePublicationToMavenLocal
       - if: github.event_name == 'push'
         uses: actions/cache@v3
         with:
           path: sdk-main.aar
           key: diffuse-${{ github.sha }}
+
   sonar:
-    name: Sonar
+    name: 'Sonar'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -60,8 +61,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonarqube --info
+
   ui-tests:
-    name: Android UI Tests
+    name: 'Android UI Tests'
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -75,10 +77,31 @@ jobs:
           java-version: '11'
           distribution: adopt
           cache: 'gradle'
+      - uses: gradle/gradle-build-action@v2
+      - name: 'AVD cache'
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+      - name: 'Create AVD and generate snapshot for caching'
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
       - uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
           arch: x86_64
           profile: Nexus 6
           script: |
@@ -89,8 +112,9 @@ jobs:
         with:
           name: androidTest-results
           path: sdk/build/outputs/androidTest-results
+
   benchmark-tests:
-    name: Android Benchmark
+    name: 'Android Benchmark'
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -120,8 +144,9 @@ jobs:
         with:
           name: benchmark-json-output
           path: benchmark/build/outputs/connected_android_test_additional_output
+
   size-report:
-    name: Diffuse report
+    name: 'Diffuse report'
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -133,7 +158,7 @@ jobs:
         java-version: '11'
         distribution: adopt
         cache: 'gradle'
-    - name: Build sdk for PR and main branch
+    - name: 'Build sdk for PR and main branch'
       run: |
         ./gradlew build --stacktrace
         cp sdk/build/outputs/aar/sdk-release.aar sdk-pr.aar
@@ -161,8 +186,9 @@ jobs:
         comment-id: ${{ steps.find_comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         token: ${{ secrets.GITHUB_TOKEN }}
+
   sdk-compile-test:
-    name: "Compile target:${{ matrix.target }} compile:${{ matrix.compile }} appcompat: ${{ matrix.appcompat }}"
+    name: 'Compile target:${{ matrix.target }} compile:${{ matrix.compile }} appcompat: ${{ matrix.appcompat }}'
     needs: [build]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           java-version: '11'
           distribution: adopt
-          cache: 'gradle'
+      - uses: gradle/gradle-build-action@v2
       - name: 'Assemble & Test'
         run: |
           ./gradlew build --stacktrace
@@ -51,7 +51,7 @@ jobs:
         with:
           java-version: '11'
           distribution: adopt
-          cache: 'gradle'
+      - uses: gradle/gradle-build-action@v2
       - uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
@@ -76,7 +76,6 @@ jobs:
         with:
           java-version: '11'
           distribution: adopt
-          cache: 'gradle'
       - uses: gradle/gradle-build-action@v2
       - name: 'AVD cache'
         uses: actions/cache@v3
@@ -127,7 +126,7 @@ jobs:
         with:
           java-version: '11'
           distribution: adopt
-          cache: 'gradle'
+      - uses: gradle/gradle-build-action@v2
       - uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
@@ -157,7 +156,7 @@ jobs:
       with:
         java-version: '11'
         distribution: adopt
-        cache: 'gradle'
+    - uses: gradle/gradle-build-action@v2
     - name: 'Build sdk for PR and main branch'
       run: |
         ./gradlew build --stacktrace
@@ -213,7 +212,7 @@ jobs:
         with:
           java-version: '11'
           distribution: adopt
-          cache: 'gradle'
+      - uses: gradle/gradle-build-action@v2
       - run: |
           ./gradlew build -PexampleCompileSdkVersion=${{ matrix.compile }} \
                           -PexampleTargetSdkVersion=${{ matrix.target }} \


### PR DESCRIPTION
* add caching wherever possible
* use official gradle action to cache gradle instead `setup-java`
  * more features, better caching
* linting: use `'` for strings 
* example pipeline run: https://github.com/hCaptcha/hcaptcha-android-sdk/actions/runs/3524163872