### PR TITLE
fix(config): serialization crash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 3.5.1
+
+- Bugfix: Parcelable encountered IOException writing serializable object (name = com.hcaptcha.sdk.HCaptchaConfig) ([#94](https://github.com/hCaptcha/hcaptcha-android-sdk/issues/94))
+
 # 3.5.0
 
 - Deprecated: `HCaptchaConfig.apiEndpoint` replaced with `HCaptchaConfig.jsSrc` option

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -22,11 +22,11 @@ android {
         // See https://developer.android.com/studio/publish/versioning
         // versionCode must be integer and be incremented by one for every new update
         // android system uses this to prevent downgrades
-        versionCode 27
+        versionCode 28
 
         // version number visible to the user
         // should follow semantic versioning (See https://semver.org)
-        versionName "3.5.0"
+        versionName "3.5.1"
 
         buildConfigField 'String', 'VERSION_NAME', "\"${defaultConfig.versionName}_${defaultConfig.versionCode}\""
 

--- a/sdk/src/androidTest/java/com/hcaptcha/sdk/HCaptchaDialogFragmentTest.java
+++ b/sdk/src/androidTest/java/com/hcaptcha/sdk/HCaptchaDialogFragmentTest.java
@@ -28,6 +28,7 @@ import android.os.Bundle;
 import android.util.AndroidRuntimeException;
 import android.view.LayoutInflater;
 import androidx.fragment.app.testing.FragmentScenario;
+import androidx.lifecycle.Lifecycle;
 import androidx.test.espresso.web.webdriver.DriverAtoms;
 import androidx.test.espresso.web.webdriver.Locator;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -263,5 +264,43 @@ public class HCaptchaDialogFragmentTest {
         waitHCaptchaWebViewErrorByInput(retryLatch, HCaptchaError.NETWORK_ERROR, AWAIT_CALLBACK_MS);
 
         assertTrue(failureLatch.await(AWAIT_CALLBACK_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testPauseResumeFragment() throws Exception {
+        final CountDownLatch successLatch = new CountDownLatch(1);
+        final HCaptchaStateListener listener = new HCaptchaStateTestAdapter() {
+
+            @Override
+            void onSuccess(String token) {
+                successLatch.countDown();
+            }
+        };
+
+        final FragmentScenario<HCaptchaDialogFragment> scenario = launchCaptchaFragment(config, listener);
+        scenario.moveToState(Lifecycle.State.STARTED).moveToState(Lifecycle.State.RESUMED);
+
+        waitHCaptchaWebViewToken(successLatch, AWAIT_CALLBACK_MS);
+
+        assertTrue(successLatch.await(AWAIT_CALLBACK_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testActivityRecreate() throws Exception {
+        final CountDownLatch successLatch = new CountDownLatch(1);
+        final HCaptchaStateListener listener = new HCaptchaStateTestAdapter() {
+
+            @Override
+            void onSuccess(String token) {
+                successLatch.countDown();
+            }
+        };
+
+        final FragmentScenario<HCaptchaDialogFragment> scenario = launchCaptchaFragment(config, listener);
+        scenario.recreate();
+
+        waitHCaptchaWebViewToken(successLatch, AWAIT_CALLBACK_MS);
+
+        assertTrue(successLatch.await(AWAIT_CALLBACK_MS, TimeUnit.MILLISECONDS));
     }
 }

--- a/sdk/src/main/java/com/hcaptcha/sdk/IHCaptchaRetryPredicate.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/IHCaptchaRetryPredicate.java
@@ -1,10 +1,12 @@
 package com.hcaptcha.sdk;
 
+import java.io.Serializable;
+
 /**
  * On failure retry decider class
  */
 @FunctionalInterface
-public interface IHCaptchaRetryPredicate {
+public interface IHCaptchaRetryPredicate extends Serializable {
 
     /**
      * Allows retrying in case of verification errors.

--- a/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaConfigTest.java
+++ b/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaConfigTest.java
@@ -5,6 +5,10 @@ import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Locale;
 
 public class HCaptchaConfigTest {
@@ -63,5 +67,19 @@ public class HCaptchaConfigTest {
         assertEquals(customTheme, config.getCustomTheme());
     }
 
+    @Test
+    public void serialization() throws Exception {
+        final HCaptchaConfig config = HCaptchaConfig.builder().siteKey(MOCK_SITE_KEY).build();
+
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        final ObjectOutputStream oos = new ObjectOutputStream(bos);
+        oos.writeObject(config);
+        final ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
+        final ObjectInputStream ois = new ObjectInputStream(bis);
+        final HCaptchaConfig deserializedObject = (HCaptchaConfig) ois.readObject();
+
+        assertEquals(config.toBuilder().retryPredicate(null).build(),
+                deserializedObject.toBuilder().retryPredicate(null).build());
+    }
 
 }


### PR DESCRIPTION
 - #94 

### Troubleshooting details

Affected versions: `>= 3.40`

The issue was introduced in 3.4.0 (https://github.com/hCaptcha/hcaptcha-android-sdk/commit/c636106addc54be20908ab365e45400fa12b4705)