### PR TITLE
fix(sdk): prevent enum's toString from obfuscation

### DIFF
--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -32,6 +32,7 @@ android {
 
     buildTypes {
         release {
+            signingConfig signingConfigs.debug
             minifyEnabled true
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0
 android.disableAutomaticComponentCreation=true
+# To test more aggressive optimizations
+android.enableR8.fullMode=true

--- a/sdk/consumer-rules.pro
+++ b/sdk/consumer-rules.pro
@@ -4,3 +4,6 @@
 
 # Prevent obfuscating the names when serializing to JSON
 -keep class com.hcaptcha.sdk.HCaptchaConfig { *; }
+-keepclasseswithmembernames public enum com.hcaptcha.sdk.** {
+    @com.fasterxml.jackson.annotation.JsonValue *;
+}


### PR DESCRIPTION
### Problem

Once ProGuard takes action it can rename `String toString()` on `HCaptchaSize`, `HCaptchaTheme`, and `HCaptchaOrientation` because of serialization, the analyzer will lose track. As a result default implementation of `String toString()` will be used which returns symbolic names for of enum i.e. `LIGHT` instead `light`

Problem reproduces for on `invisible`, `onPass` never called in this case

### Fix

We should keep ProGuard out of `toString` on enums