### PR TITLE
fix: calling webView.loadUrl on destroyed WebView

### DIFF
--- a/benchmark/src/androidTest/java/com/hcaptcha/sdk/HCaptchaWebViewHelperTest.java
+++ b/benchmark/src/androidTest/java/com/hcaptcha/sdk/HCaptchaWebViewHelperTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.fail;
 
 import android.os.Handler;
 import android.os.Looper;
-import android.webkit.WebView;
 
 import androidx.benchmark.BenchmarkState;
 import androidx.benchmark.junit4.BenchmarkRule;
@@ -44,7 +43,7 @@ public class HCaptchaWebViewHelperTest {
             final CountDownLatch latch = new CountDownLatch(1);
             try {
                 rule.getScenario().onActivity(activity -> {
-                    WebView webView = new WebView(activity);
+                    HCaptchaWebView webView = new HCaptchaWebView(activity);
                     state.resumeTiming();
                     new HCaptchaWebViewHelper(
                             handler,

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -49,7 +49,6 @@ android {
     }
 
     testOptions {
-        animationsDisabled = true
         unitTests {
             returnDefaultValues = true
             includeAndroidResources = true

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaHeadlessWebView.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaHeadlessWebView.java
@@ -32,7 +32,7 @@ final class HCaptchaHeadlessWebView implements IHCaptchaVerifier {
         HCaptchaLog.d("HeadlessWebView.init");
         this.config = config;
         this.listener = listener;
-        final WebView webView = new HCaptchaWebView(activity);
+        final HCaptchaWebView webView = new HCaptchaWebView(activity);
         webView.setId(R.id.webView);
         webView.setVisibility(View.GONE);
         if (webView.getParent() == null) {

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaWebView.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaWebView.java
@@ -46,4 +46,8 @@ public class HCaptchaWebView extends WebView {
     public boolean performClick() {
         return false;
     }
+
+    public boolean isDestroyed() {
+        return getParent() == null;
+    }
 }

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaWebViewHelper.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaWebViewHelper.java
@@ -39,7 +39,7 @@ final class HCaptchaWebViewHelper {
 
     @Getter
     @NonNull
-    private final WebView webView;
+    private final HCaptchaWebView webView;
 
     @NonNull
     private final IHCaptchaHtmlProvider htmlProvider;
@@ -50,7 +50,7 @@ final class HCaptchaWebViewHelper {
                           @NonNull final HCaptchaInternalConfig internalConfig,
                           @NonNull final IHCaptchaVerifier captchaVerifier,
                           @NonNull final HCaptchaStateListener listener,
-                          @NonNull final WebView webView) {
+                          @NonNull final HCaptchaWebView webView) {
         this.context = context;
         this.config = config;
         this.captchaVerifier = captchaVerifier;
@@ -113,7 +113,11 @@ final class HCaptchaWebViewHelper {
     }
 
     void reset() {
-        webView.loadUrl("javascript:reset();");
+        if (webView.isDestroyed()) {
+            HCaptchaLog.w("WebView is destroyed already");
+        } else {
+            webView.loadUrl("javascript:reset();");
+        }
     }
 
     public boolean shouldRetry(HCaptchaException exception) {

--- a/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaWebViewHelperTest.java
+++ b/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaWebViewHelperTest.java
@@ -15,7 +15,6 @@ import android.util.Log;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.webkit.WebSettings;
-import android.webkit.WebView;
 
 import org.junit.After;
 import org.junit.Before;
@@ -46,7 +45,7 @@ public class HCaptchaWebViewHelperTest {
     HCaptchaStateListener stateListener;
 
     @Mock
-    WebView webView;
+    HCaptchaWebView webView;
 
     @Mock
     WebSettings webSettings;
@@ -64,7 +63,7 @@ public class HCaptchaWebViewHelperTest {
         MockitoAnnotations.openMocks(this);
         androidLogMock = mockStatic(Log.class);
         stateListener = mock(HCaptchaStateListener.class);
-        webView = mock(WebView.class);
+        webView = mock(HCaptchaWebView.class);
         webSettings = mock(WebSettings.class);
         htmlProvider = mock(IHCaptchaHtmlProvider.class);
         when(htmlProvider.getHtml()).thenReturn(MOCK_HTML);

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -32,6 +32,9 @@ android {
     }
 
     testBuildType = project.hasProperty("testingMinimizedBuild") ? "release" : "debug"
+    testOptions {
+        animationsDisabled = true
+    }
 }
 
 androidComponents {

--- a/test/src/androidTest/java/com/hcaptcha/sdk/HCaptchaWebViewHelperTest.java
+++ b/test/src/androidTest/java/com/hcaptcha/sdk/HCaptchaWebViewHelperTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 
 import android.os.Handler;
 import android.os.Looper;
-import android.webkit.WebView;
 
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
@@ -63,7 +62,7 @@ public class HCaptchaWebViewHelperTest {
 
         final ActivityScenario<TestActivity> scenario = rule.getScenario();
         scenario.onActivity(activity -> {
-            WebView webView = new WebView(activity);
+            HCaptchaWebView webView = new HCaptchaWebView(activity);
             final HCaptchaWebViewHelper helper = new HCaptchaWebViewHelper(
                     handler, activity, config, internalConfig, verifier, listener, webView);
         });


### PR DESCRIPTION
### Problem

If `HCaptcha.reset` is called after verification is finished (doesn't mater successful or not) message below gets printed to logcat by the system:

```
Application attempted to call on a destroyed WebView
java.lang.Throwable
	at org.chromium.android_webview.AwContents.s(chromium-TrichromeWebViewGoogle6432.aab-stable-609904333:10)
	at com.android.webview.chromium.WebViewChromium.loadUrl(chromium-TrichromeWebViewGoogle6432.aab-stable-609904333:15)
	at android.webkit.WebView.loadUrl(WebView.java:743)
	at com.hcaptcha.sdk.HCaptchaWebViewHelper.reset(Unknown Source:4)
	at com.hcaptcha.sdk.HCaptchaDialogFragment.reset(Unknown Source:4)
	at com.hcaptcha.sdk.HCaptcha.reset(Unknown Source:4)
	at Hcaptcha.reset$lambda$5(Hcaptcha.kt:112)
	at Hcaptcha.$r8$lambda$Z8mwFMXoe_rKDOgMykL8R7w_6Zw(Unknown Source:0)
	at Hcaptcha$$ExternalSyntheticLambda1.run(Unknown Source:2)
	at android.os.Handler.handleCallback(Handler.java:958)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:205)
	at android.os.Looper.loop(Looper.java:294)
	at android.app.ActivityThread.main(ActivityThread.java:8177)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
```

To improve dev experience make sense to handle this situation, and keep logcat less poluted

It's not a crash just logcat