### PR TITLE
feat: drop diagnostic logs from production code

### DIFF
--- a/sdk/consumer-rules.pro
+++ b/sdk/consumer-rules.pro
@@ -11,3 +11,8 @@
 -keepclasseswithmembernames public enum com.hcaptcha.sdk.** {
     @com.fasterxml.jackson.annotation.JsonValue *;
 }
+
+# Remove debug logging from the production code
+-assumenosideeffects class com.hcaptcha.sdk.HCaptchaLog {
+    *;
+}


### PR DESCRIPTION
There isn't much benefit in having this in production and removing it reduces the final APK size a bit

UPD:
- -556bytes on sample app apk
- less stress on logcat