### PR TITLE
fix: handle null internal config in args for HCaptchaDialogFragment

### DIFF
--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaDialogFragment.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaDialogFragment.java
@@ -98,14 +98,17 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
         HCaptchaStateListener listener = null;
         try {
             final Bundle args = getArguments();
-            assert args != null;
             listener = HCaptchaCompat.getParcelable(args, KEY_LISTENER, HCaptchaStateListener.class);
-            assert listener != null;
             final HCaptchaConfig config = HCaptchaCompat.getSerializable(args, KEY_CONFIG, HCaptchaConfig.class);
-            assert config != null;
             final HCaptchaInternalConfig internalConfig = HCaptchaCompat.getSerializable(args,
                     KEY_INTERNAL_CONFIG, HCaptchaInternalConfig.class);
-            assert internalConfig != null;
+
+            if (listener == null || config == null || internalConfig == null) {
+                // According to Firebase Analytics, there are cases where Bundle args are empty.
+                // > 90% of these cases occur on Android 6, and the count of crashes <<< the count of sessions.
+                // This is a quick fix to prevent crashes in production
+                throw new AssertionError();
+            }
 
             if (inflater == null) {
                 throw new InflateException("inflater is null");


### PR DESCRIPTION
### Issue details

<img width="480" alt="Screenshot 2023-12-22 at 4 28 17 PM" src="https://github.com/hCaptcha/hcaptcha-android-sdk/assets/2169738/57310390-a895-45b2-9c6c-e4e0ca9f7bdb">
<img width="480" alt="Screenshot 2023-12-22 at 4 28 56 PM" src="https://github.com/hCaptcha/hcaptcha-android-sdk/assets/2169738/e821ef60-5e15-48da-b68b-75add98b93e3">

### Explanation

The crash looks like a bug in Android itself. This PR is not to fix the issue but to prevent host app from crashing

Open for discussion, to find a better solution