### PR TITLE
ci: use fresh AVD from benchmark tests

### DIFF
--- a/.github/actions/android-emulator-run/action.yml
+++ b/.github/actions/android-emulator-run/action.yml
@@ -25,11 +25,16 @@ inputs:
     description: Emulator boot options
     required: true
     default: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+  fresh-avd:
+    description: Force AVD creation and skip cache
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
   steps:
   - name: Cache AVD
+    if: inputs.fresh-avd != 'true'
     uses: actions/cache@v4
     id: avd-cache
     with:
@@ -45,7 +50,7 @@ runs:
       sudo udevadm control --reload-rules
       sudo udevadm trigger --name-match=kvm
   - name: 'Create AVD'
-    if: steps.avd-cache.outputs.cache-hit != 'true'
+    if: inputs.fresh-avd != 'true' && steps.avd-cache.outputs.cache-hit != 'true'
     uses: reactivecircus/android-emulator-runner@v2
     with:
       arch: ${{ inputs.arch }}
@@ -63,6 +68,6 @@ runs:
       profile: ${{ inputs.profile }}
       api-level: ${{ inputs.api-level }}
       emulator-options: ${{ inputs.boot-options }}
-      force-avd-creation: false
+      force-avd-creation: ${{ inputs.fresh-avd == 'true' }}
       disable-animations: true
       script: ${{ inputs.script }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
         uses: ./.github/actions/android-emulator-run
         with:
           api-level: 29
+          fresh-avd: true
           script: |
             adb uninstall com.hcaptcha.sdk.bench.test || true
             ./gradlew benchmark:connectedReleaseAndroidTest


### PR DESCRIPTION
Caching AVD for Android is a questionable practice due to the complexity of emulator setup and unwanted states that should not be stored between CI runs. As a result, this leads to unstable tests on CI.

We definitely should avoid it for benchmarking, as the environment must be as clean as possible between runs.