### PR TITLE
feat: improve error message on invalid site-key

### DIFF
--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaConfig.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaConfig.java
@@ -181,5 +181,15 @@ public class HCaptchaConfig implements Serializable {
             this.jsSrc(url);
             return this;
         }
+
+        public HCaptchaConfigBuilder siteKey(@NonNull String siteKey) {
+            try {
+                java.util.UUID.fromString(siteKey);
+                this.siteKey = siteKey;
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("hCaptcha site-key must be a valid UUID", e);
+            }
+            return this;
+        }
     }
 }

--- a/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaConfigTest.java
+++ b/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaConfigTest.java
@@ -13,7 +13,7 @@ import java.util.Locale;
 
 public class HCaptchaConfigTest {
 
-    public static final String MOCK_SITE_KEY = "mocked-site-key";
+    public static final String MOCK_SITE_KEY = "00000000-0000-0000-0000-000000000000";
 
     @Test
     public void custom_locale() {
@@ -90,4 +90,8 @@ public class HCaptchaConfigTest {
                 deserializedObject.toBuilder().retryPredicate(null).build());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void invalid_site_key() {
+        HCaptchaConfig.builder().siteKey("invalid-uuid-site-key").build();
+    }
 }

--- a/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaJSInterfaceTest.java
+++ b/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaJSInterfaceTest.java
@@ -36,7 +36,7 @@ public class HCaptchaJSInterfaceTest {
     @Captor
     ArgumentCaptor<HCaptchaException> exceptionCaptor;
 
-    HCaptchaConfig testConfig = HCaptchaConfig.builder().siteKey("0000-1111-2222-3333").build();
+    HCaptchaConfig testConfig = HCaptchaConfig.builder().siteKey(HCaptchaConfigTest.MOCK_SITE_KEY).build();
 
     @Before
     public void init() {
@@ -48,7 +48,7 @@ public class HCaptchaJSInterfaceTest {
 
     @Test
     public void full_config_serialization() throws JSONException {
-        final String siteKey = "0000-1111-2222-3333";
+        final String siteKey = HCaptchaConfigTest.MOCK_SITE_KEY;
         final String locale = "ro";
         final HCaptchaOrientation orientation = HCaptchaOrientation.PORTRAIT;
         final HCaptchaSize size = HCaptchaSize.NORMAL;
@@ -108,7 +108,7 @@ public class HCaptchaJSInterfaceTest {
 
     @Test
     public void subset_config_serialization() throws JSONException {
-        final String siteKey = "0000-1111-2222-3333";
+        final String siteKey = HCaptchaConfigTest.MOCK_SITE_KEY;
         final String locale = "ro";
         final HCaptchaSize size = HCaptchaSize.NORMAL;
         final HCaptchaOrientation orientation = HCaptchaOrientation.LANDSCAPE;

--- a/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaTest.java
+++ b/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaTest.java
@@ -37,6 +37,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Locale;
+import java.util.UUID;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -201,7 +202,7 @@ public class HCaptchaTest {
     @Test
     public void test_verify_config_has_priority_over_setup_config() throws Exception {
         final HCaptchaConfig verifyConfig = HCaptchaConfig.builder()
-                .siteKey(HCaptchaConfigTest.MOCK_SITE_KEY + "-on-verify")
+                .siteKey(HCaptchaConfigTest.MOCK_SITE_KEY)
                 .size(HCaptchaSize.INVISIBLE)
                 .loading(false)
                 .build();
@@ -222,7 +223,7 @@ public class HCaptchaTest {
 
     @Test
     public void test_verify_site_key_has_priority_over_setup_config() throws Exception {
-        final String siteKey = HCaptchaConfigTest.MOCK_SITE_KEY + "-on-verify";
+        final String siteKey = UUID.randomUUID().toString();
         HCaptcha.getClient(fragmentActivity)
                 .setup(config)
                 .verifyWithHCaptcha(siteKey);

--- a/test/src/androidTest/java/com/hcaptcha/sdk/compose/HCaptchaComposeTest.kt
+++ b/test/src/androidTest/java/com/hcaptcha/sdk/compose/HCaptchaComposeTest.kt
@@ -1,7 +1,5 @@
 package com.hcaptcha.sdk.compose
 
-import androidx.compose.ui.test.*
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
@@ -11,6 +9,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.hcaptcha.sdk.HCaptchaCompose
 import com.hcaptcha.sdk.HCaptchaConfig
@@ -66,13 +66,10 @@ class HCaptchaComposeTest {
                 .assertTextEquals("10000000-aaaa-bbbb-cccc-000000000001")
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException::class)
     fun invalidToken() {
-        setContent("")
+        setContent("bad-token")
 
         runBlocking { delay(timeout) }
-
-        composeTestRule.onNodeWithContentDescription(resultContentDescription)
-            .assertTextContains(HCaptchaError.ERROR.name)
     }
 }


### PR DESCRIPTION
# Problem

Currently, when the user passes an invalid `siteKey`, for example with `–` (long dash) instead `-`, SDK will throw not very  verr descriptive error like:

`HCaptchaException(hCaptchaError=Invalid data is not accepted by endpoints, message=Invalid data is not accepted by endpoints)`

# Solution

Throw `IllegalArgumentException("hCaptcha site-key must be a valid UUID")`

P.S. Are our site-keys always valid UUID https://www.ietf.org/rfc/rfc4122.txt?