### PR TITLE
fix: build.gradle downgrade to 2.13.5

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -70,7 +70,8 @@ android {
 dependencies {
     //noinspection GradleDependency
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.3'
+    //noinspection GradleDependency
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.5' // max version https://github.com/FasterXML/jackson-databind/issues/3657
     compileOnly 'org.projectlombok:lombok:1.18.32'
     annotationProcessor 'org.projectlombok:lombok:1.18.32'
 


### PR DESCRIPTION
Jackson 2.14 will require Android SDK 26 so downgrading back to 2.13.x

Related: https://github.com/hCaptcha/hcaptcha-android-sdk/issues/170