### PR TITLE
journeylitics: fix global sink handling + press scope unlock

### DIFF
--- a/compose-sdk/build.gradle
+++ b/compose-sdk/build.gradle
@@ -64,6 +64,7 @@ android {
 dependencies {
     api project(':sdk')
     implementation "androidx.compose.foundation:foundation:$compose_version"
+    testImplementation 'junit:junit:4.13.2'
 }
 
 project.afterEvaluate {

--- a/compose-sdk/src/main/java/com/hcaptcha/sdk/journeylitics/ComposeAnalytics.kt
+++ b/compose-sdk/src/main/java/com/hcaptcha/sdk/journeylitics/ComposeAnalytics.kt
@@ -369,12 +369,16 @@ private class PressGestureScopeImpl(
 
     fun cancel() {
         isCanceled = true
-        mutex.unlock()
+        if (mutex.isLocked) {
+            mutex.unlock()
+        }
     }
 
     fun release() {
         isReleased = true
-        mutex.unlock()
+        if (mutex.isLocked) {
+            mutex.unlock()
+        }
     }
 
     suspend fun reset() {

--- a/compose-sdk/src/test/java/com/hcaptcha/sdk/journeylitics/PressGestureScopeImplTest.kt
+++ b/compose-sdk/src/test/java/com/hcaptcha/sdk/journeylitics/PressGestureScopeImplTest.kt
@@ -1,0 +1,47 @@
+package com.hcaptcha.sdk.journeylitics
+
+import androidx.compose.ui.unit.Density
+import org.junit.Test
+
+class PressGestureScopeImplTest {
+    private fun newInstance(): Any {
+        val classNames = listOf(
+            "com.hcaptcha.sdk.journeylitics.PressGestureScopeImpl",
+            "com.hcaptcha.sdk.journeylitics.ComposeAnalyticsKt\$PressGestureScopeImpl"
+        )
+        var clazz: Class<*>? = null
+        for (name in classNames) {
+            try {
+                clazz = Class.forName(name)
+                break
+            } catch (_: ClassNotFoundException) {
+                // Try next name
+            }
+        }
+        requireNotNull(clazz) { "PressGestureScopeImpl class not found" }
+
+        val ctor = clazz.getDeclaredConstructor(Density::class.java)
+        ctor.isAccessible = true
+        val density = object : Density {
+            override val density: Float = 1f
+            override val fontScale: Float = 1f
+        }
+        return ctor.newInstance(density)
+    }
+
+    @Test
+    fun cancelWithoutReset_doesNotThrow() {
+        val instance = newInstance()
+        val cancel = instance.javaClass.getDeclaredMethod("cancel")
+        cancel.isAccessible = true
+        cancel.invoke(instance)
+    }
+
+    @Test
+    fun releaseWithoutReset_doesNotThrow() {
+        val instance = newInstance()
+        val release = instance.javaClass.getDeclaredMethod("release")
+        release.isAccessible = true
+        release.invoke(instance)
+    }
+}

--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptcha.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptcha.java
@@ -105,11 +105,22 @@ public final class HCaptcha extends Task<HCaptchaTokenResponse> implements IHCap
             }
         };
         try {
-            // Initialize user journey tracking if enabled
-            if (Boolean.TRUE.equals(inputConfig.getUserJourney()) && journeySink == null) {
-                journeySink = new InMemorySink();
-                final JLConfig jlConfig = new JLConfig(journeySink);
-                Journeylitics.start(activity, jlConfig);
+            // Initialize or disable user journey tracking if enabled/disabled
+            if (Boolean.TRUE.equals(inputConfig.getUserJourney())) {
+                if (journeySink == null) {
+                    journeySink = new InMemorySink();
+                }
+                if (Journeylitics.isStarted()) {
+                    Journeylitics.addSink(journeySink);
+                } else {
+                    final JLConfig jlConfig = new JLConfig(journeySink);
+                    Journeylitics.start(activity, jlConfig);
+                }
+            } else if (journeySink != null) {
+                if (Journeylitics.isStarted()) {
+                    Journeylitics.removeSink(journeySink);
+                }
+                journeySink = null;
             }
 
             if (Boolean.TRUE.equals(inputConfig.getHideDialog())) {

--- a/sdk/src/main/java/com/hcaptcha/sdk/journeylitics/Journeylitics.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/journeylitics/Journeylitics.java
@@ -137,11 +137,18 @@ public class Journeylitics {
         sApp.registerActivityLifecycleCallbacks(LIFECYCLE_CALLBACKS);
     }
 
-    static void addSink(JLSink sink) {
+    public static boolean isStarted() {
+        return STARTED.get();
+    }
+
+    public static void addSink(JLSink sink) {
+        if (sink == null || SINKS.contains(sink)) {
+            return;
+        }
         SINKS.add(sink);
     }
 
-    static void removeSink(JLSink sink) {
+    public static void removeSink(JLSink sink) {
         SINKS.remove(sink);
     }
 
@@ -652,4 +659,3 @@ public class Journeylitics {
         }
     }
 }
-

--- a/sdk/src/test/java/com/hcaptcha/sdk/journeylitics/JourneyliticsTest.java
+++ b/sdk/src/test/java/com/hcaptcha/sdk/journeylitics/JourneyliticsTest.java
@@ -1,18 +1,46 @@
 package com.hcaptcha.sdk.journeylitics;
 
+import android.app.Application;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class JourneyliticsTest {
+    private static final String VIEW_BUTTON = "Button";
     private final List<JLEvent> captured = new ArrayList<>();
+
+    private static void resetJourneyliticsState() throws Exception {
+        final Field startedField = Journeylitics.class.getDeclaredField("STARTED");
+        startedField.setAccessible(true);
+        ((AtomicBoolean) startedField.get(null)).set(false);
+
+        final Field appField = Journeylitics.class.getDeclaredField("sApp");
+        appField.setAccessible(true);
+        appField.set(null, null);
+
+        final Field configField = Journeylitics.class.getDeclaredField("sConfig");
+        configField.setAccessible(true);
+        configField.set(null, JLConfig.DEFAULT);
+
+        final Field sinksField = Journeylitics.class.getDeclaredField("SINKS");
+        sinksField.setAccessible(true);
+        ((List<?>) sinksField.get(null)).clear();
+
+        final Field instrumentedField = Journeylitics.class.getDeclaredField("INSTRUMENTED");
+        instrumentedField.setAccessible(true);
+        ((Map<?, ?>) instrumentedField.get(null)).clear();
+    }
 
     @Test
     public void sink_emits_event() {
@@ -27,14 +55,14 @@ public class JourneyliticsTest {
         final Map<String, Object> meta = MetaMapHelper.createMetaMap(
             new AbstractMap.SimpleEntry<>(FieldKey.ID, "test-button")
         );
-        sink.emit(new JLEvent(EventKind.click, "Button", new HashMap<>(meta)));
+        sink.emit(new JLEvent(EventKind.click, VIEW_BUTTON, new HashMap<>(meta)));
         Assert.assertTrue(captured.size() == before + 1);
     }
 
     @Test
     public void metadata_serializes_as_string() throws Exception {
         final ObjectMapper mapper = new ObjectMapper();
-        final JLEvent event = new JLEvent(1234567890L, EventKind.click, "Button", "meta-string");
+        final JLEvent event = new JLEvent(1234567890L, EventKind.click, VIEW_BUTTON, "meta-string");
         final JsonNode node = mapper.readTree(mapper.writeValueAsString(event));
         Assert.assertEquals("meta-string", node.get("m").asText());
     }
@@ -44,9 +72,45 @@ public class JourneyliticsTest {
         final ObjectMapper mapper = new ObjectMapper();
         final Map<String, Object> meta = new HashMap<>();
         meta.put("id", "submit-btn");
-        final JLEvent event = new JLEvent(1234567890L, EventKind.click, "Button", meta);
+        final JLEvent event = new JLEvent(1234567890L, EventKind.click, VIEW_BUTTON, meta);
         final JsonNode node = mapper.readTree(mapper.writeValueAsString(event));
         Assert.assertEquals("submit-btn", node.get("m").get("id").asText());
     }
-}
 
+    @Test
+    public void addSink_afterStart_receivesEvents() throws Exception {
+        resetJourneyliticsState();
+        final Application app = Mockito.mock(Application.class);
+        Mockito.when(app.getApplicationContext()).thenReturn(app);
+        Journeylitics.start(app, new JLConfig());
+
+        final List<JLEvent> events = new ArrayList<>();
+        final JLSink sink = events::add;
+        Journeylitics.addSink(sink);
+
+        final Map<String, Object> meta = MetaMapHelper.createMetaMap(
+            new AbstractMap.SimpleEntry<>(FieldKey.ID, "test-button")
+        );
+        Journeylitics.emit(EventKind.click, VIEW_BUTTON, meta);
+        Assert.assertEquals(1, events.size());
+    }
+
+    @Test
+    public void removeSink_stopsEvents() throws Exception {
+        resetJourneyliticsState();
+        final Application app = Mockito.mock(Application.class);
+        Mockito.when(app.getApplicationContext()).thenReturn(app);
+        Journeylitics.start(app, new JLConfig());
+
+        final List<JLEvent> events = new ArrayList<>();
+        final JLSink sink = events::add;
+        Journeylitics.addSink(sink);
+
+        Journeylitics.emit(EventKind.click, VIEW_BUTTON, new HashMap<>());
+        Assert.assertEquals(1, events.size());
+
+        Journeylitics.removeSink(sink);
+        Journeylitics.emit(EventKind.click, VIEW_BUTTON, new HashMap<>());
+        Assert.assertEquals(1, events.size());
+    }
+}


### PR DESCRIPTION
- add Journeylitics.isStarted() and guard addSink from duplicates
- register/remove the per-instance sink in HCaptcha.setup() based on userJourney
  so global tracking keeps collecting events across instances and disables cleanly
- make PressGestureScopeImpl.cancel/release no-op if mutex not locked to avoid
  IllegalStateException
- add unit tests for sink add/remove behavior and press-scope no-crash cases
- add JUnit dependency for compose module tests