### PR TITLE
fix: eliminate auto-generated PNG density variants for ic_hcaptcha_logo (#233)

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -25,6 +25,8 @@ android {
         minSdkVersion 16
         targetSdkVersion 35
 
+        vectorDrawables.useSupportLibrary = true
+
         // See https://developer.android.com/studio/publish/versioning
         // versionCode must be integer and be incremented by one for every new update
         // android system uses this to prevent downgrades

--- a/sdk/src/main/res/layout/hcaptcha_fragment.xml
+++ b/sdk/src/main/res/layout/hcaptcha_fragment.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -24,7 +25,7 @@
             android:layout_width="150dp"
             android:layout_height="wrap_content"
             android:adjustViewBounds="true"
-            android:src="@drawable/ic_hcaptcha_logo"
+            app:srcCompat="@drawable/ic_hcaptcha_logo"
             android:contentDescription="@string/logo_description" />
 
         <ProgressBar


### PR DESCRIPTION
- #233 

Enable vectorDrawables.useSupportLibrary in SDK defaultConfig and use app:srcCompat instead of android:src, so the AGP no longer generates ~50 KB of unnecessary PNG fallbacks for each density bucket.