### PR TITLE
fix: preserve hCaptcha logo when using vector drawable support

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-inline:4.8.1'
     testImplementation 'org.skyscreamer:jsonassert:1.5.1'
+    testImplementation 'org.robolectric:robolectric:4.8.2'
 
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
 }

--- a/sdk/src/main/res/layout/hcaptcha_fragment.xml
+++ b/sdk/src/main/res/layout/hcaptcha_fragment.xml
@@ -21,7 +21,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content">
 
-        <ImageView
+        <androidx.appcompat.widget.AppCompatImageView
             android:layout_width="150dp"
             android:layout_height="wrap_content"
             android:adjustViewBounds="true"

--- a/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaFragmentLayoutTest.java
+++ b/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaFragmentLayoutTest.java
@@ -1,0 +1,40 @@
+package com.hcaptcha.sdk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import android.app.Dialog;
+import android.os.Build;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import androidx.appcompat.widget.AppCompatImageView;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.S_V2)
+public class HCaptchaFragmentLayoutTest {
+    @Test
+    public void layoutInflatedThroughPlainDialog_doesNotApplySrcCompat() {
+        final Dialog dialog = new Dialog(RuntimeEnvironment.getApplication(), R.style.HCaptchaDialogTheme);
+        final LayoutInflater inflater = LayoutInflater.from(RuntimeEnvironment.getApplication())
+                .cloneInContext(dialog.getContext());
+
+        final ImageView logo = inflateLogo(inflater);
+
+        assertEquals(AppCompatImageView.class, logo.getClass());
+        assertNotNull(logo.getDrawable());
+    }
+
+    private static ImageView inflateLogo(LayoutInflater inflater) {
+        final View rootView = inflater.inflate(R.layout.hcaptcha_fragment, null, false);
+        final LinearLayout loadingContainer = rootView.findViewById(R.id.loadingContainer);
+        return (ImageView) loadingContainer.getChildAt(0);
+    }
+}


### PR DESCRIPTION
## Summary
This fixes a regression introduced by the PNG density-variant optimization in `1d4778969f6feba5d0f6ec9923ac0efbeb37c88a`.

That change correctly enabled `vectorDrawables.useSupportLibrary` and replaced `android:src` with `app:srcCompat` to avoid generating density-specific PNG fallbacks. The problem is that `HCaptchaDialogFragment` still inflates `hcaptcha_fragment.xml` through the plain `DialogFragment` / `android.app.Dialog` path. With a framework `ImageView`, `app:srcCompat` is ignored, so the loading logo drawable is never set at runtime.

## Fix
- Replace the layout tag with `androidx.appcompat.widget.AppCompatImageView`
- Keep `app:srcCompat` and `vectorDrawables.useSupportLibrary = true`
- Avoid broader changes to dialog construction, theming, or inflater setup

Using the explicit AppCompat widget is the narrowest and most compatible fix because it preserves the size reduction goal while making vector inflation work on the existing production path down to the module's supported API levels.

## Test coverage
- Add a Robolectric regression test that inflates the layout through the same plain `Dialog` context used by the fragment
- Assert that the logo view is an `AppCompatImageView`
- Assert that the logo drawable is non-null after inflation

## Verification
- `./gradlew :sdk:testDebugUnitTest --tests '*HCaptchaFragmentLayoutTest'`
- `./gradlew :sdk:testDebugUnitTest`
- Repository pre-commit hook completed successfully during commit creation
