### PR TITLE
Fix empty verify params bridge data

### DIFF
--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaWebViewHelper.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaWebViewHelper.java
@@ -119,6 +119,10 @@ final class HCaptchaWebViewHelper {
             }
         }
 
+        if (verifyParams.equals(new HCaptchaVerifyParams())) {
+            return;
+        }
+
         try {
             final ObjectMapper objectMapper = new ObjectMapper();
             final String data = objectMapper.writeValueAsString(verifyParams);

--- a/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaWebViewHelperTest.java
+++ b/sdk/src/test/java/com/hcaptcha/sdk/HCaptchaWebViewHelperTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -105,5 +106,50 @@ public class HCaptchaWebViewHelperTest {
         when(config.getBaseUrl()).thenReturn(host);
         new HCaptchaWebViewHelper(handler, context, config, internalConfig, captchaVerifier, webView);
         verify(webView).loadDataWithBaseURL(host, MOCK_HTML, "text/html", "UTF-8", null);
+    }
+
+    @Test
+    public void test_set_verify_params_with_null_does_not_call_set_data() {
+        final HCaptchaWebViewHelper webViewHelper = new HCaptchaWebViewHelper(handler, context, config,
+                internalConfig, captchaVerifier, webView);
+
+        webViewHelper.setVerifyParams(null);
+
+        verify(webView, never()).loadUrl(anyString());
+    }
+
+    @Test
+    public void test_set_verify_params_with_empty_params_does_not_call_set_data() {
+        final HCaptchaWebViewHelper webViewHelper = new HCaptchaWebViewHelper(handler, context, config,
+                internalConfig, captchaVerifier, webView);
+
+        webViewHelper.setVerifyParams(HCaptchaVerifyParams.builder().build());
+
+        verify(webView, never()).loadUrl(anyString());
+    }
+
+    @Test
+    public void test_set_verify_params_with_null_uses_config_rqdata() {
+        final String rqdata = "test-rqdata-from-config";
+        when(config.getRqdata()).thenReturn(rqdata);
+        final HCaptchaWebViewHelper webViewHelper = new HCaptchaWebViewHelper(handler, context, config,
+                internalConfig, captchaVerifier, webView);
+
+        webViewHelper.setVerifyParams(null);
+
+        verify(webView).loadUrl("javascript:setData({\"rqdata\":\"" + rqdata + "\"});");
+    }
+
+    @Test
+    public void test_set_verify_params_with_user_journey_calls_set_data() {
+        final HCaptchaVerifyParams params = HCaptchaVerifyParams.builder()
+                .userJourney("test-user-journey")
+                .build();
+        final HCaptchaWebViewHelper webViewHelper = new HCaptchaWebViewHelper(handler, context, config,
+                internalConfig, captchaVerifier, webView);
+
+        webViewHelper.setVerifyParams(params);
+
+        verify(webView).loadUrl("javascript:setData({\"userjourney\":\"test-user-journey\"});");
     }
 }

--- a/test/src/androidTest/java/com/hcaptcha/sdk/HCaptchaWebViewHelperTest.java
+++ b/test/src/androidTest/java/com/hcaptcha/sdk/HCaptchaWebViewHelperTest.java
@@ -2,6 +2,7 @@ package com.hcaptcha.sdk;
 
 import static com.hcaptcha.sdk.AssertUtil.failAsNonReachable;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import android.app.Activity;
@@ -135,11 +136,8 @@ public class HCaptchaWebViewHelperTest {
             helper.setVerifyParams(null);
         });
 
-        // Wait for and get the parsed JSON
-        HCaptchaVerifyParams receivedParams = testObject.waitForSetData();
-
-        // Verify null case is handled correctly
-        assertEquals("Should return empty verify params for null parameters", new HCaptchaVerifyParams(), receivedParams);
+        // Verify null case does not call hcaptcha.setData with an empty object.
+        testObject.assertSetDataNotCalled();
     }
 
     @Test
@@ -286,6 +284,11 @@ public class HCaptchaWebViewHelperTest {
             assertTrue("setData should be called within timeout",
                 setDataLatch.await(AWAIT_CALLBACK_MS, TimeUnit.MILLISECONDS));
             return receivedParams;
+        }
+
+        public void assertSetDataNotCalled() throws InterruptedException {
+            assertFalse("setData should not be called for empty verify params",
+                    setDataLatch.await(500, TimeUnit.MILLISECONDS));
         }
     }
 }


### PR DESCRIPTION
## Summary
- skip hcaptcha.setData when verify params are null or empty
- preserve config.rqdata fallback behavior
- update unit and instrumentation expectations for the null-params path

## Testing
- ./gradlew :sdk:testDebugUnitTest --tests com.hcaptcha.sdk.HCaptchaWebViewHelperTest
- ./gradlew :sdk:check
- ./gradlew :test:compileDebugAndroidTestJavaWithJavac
- pre-commit hook: ./gradlew check