### PR TITLE
Fix dialog loaded lifecycle race

### DIFF
--- a/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaDialogFragment.java
+++ b/sdk/src/main/java/com/hcaptcha/sdk/HCaptchaDialogFragment.java
@@ -67,6 +67,10 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
 
     private boolean readyForInteraction = false;
 
+    private boolean webViewLoaded = false;
+
+    private boolean replayLoadedOnStart = false;
+
     @Nullable
     private static HCaptchaWebView sPreloadWebView;
 
@@ -197,6 +201,7 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
         HCaptchaLog.d("DialogFragment.onDestroy");
         super.onDestroy();
         readyForInteraction = false;
+        replayLoadedOnStart = webViewLoaded;
         if (webViewHelper != null) {
             webViewHelper.reset();
         }
@@ -216,7 +221,8 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
                 window.setDimAmount(0);
             }
         }
-        if (!readyForInteraction && webViewHelper != null) {
+        if (!readyForInteraction && webViewHelper != null && replayLoadedOnStart) {
+            replayLoadedOnStart = false;
             HCaptchaLog.d("DialogFragment.onStart: re-triggering onLoaded after reset");
             onLoaded();
         }
@@ -258,6 +264,7 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
             HCaptchaLog.w("DialogFragment.onLoaded webViewHelper == null, likely about to destroy");
             return;
         }
+        webViewLoaded = true;
         if (listener != null) {
             listener.onLoaded();
         }
@@ -371,6 +378,8 @@ public final class HCaptchaDialogFragment extends DialogFragment implements IHCa
         if (webViewHelper != null) {
             webViewHelper.reset();
         }
+        webViewLoaded = false;
+        replayLoadedOnStart = false;
         if (isAdded()) {
             dismissAllowingStateLoss();
         }

--- a/test/src/androidTest/java/com/hcaptcha/sdk/HCaptchaDialogFragmentTest.java
+++ b/test/src/androidTest/java/com/hcaptcha/sdk/HCaptchaDialogFragmentTest.java
@@ -3,6 +3,7 @@ package com.hcaptcha.sdk;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.espresso.intent.Intents.intending;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasData;
@@ -14,8 +15,8 @@ import static androidx.test.espresso.web.sugar.Web.onWebView;
 import static androidx.test.espresso.web.webdriver.DriverAtoms.clearElement;
 import static androidx.test.espresso.web.webdriver.DriverAtoms.findElement;
 import static androidx.test.espresso.web.webdriver.DriverAtoms.webClick;
-import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static com.hcaptcha.sdk.AssertUtil.evaluateJavascript;
 import static com.hcaptcha.sdk.AssertUtil.waitHCaptchaWebViewErrorByInput;
 import static com.hcaptcha.sdk.AssertUtil.waitHCaptchaWebViewToken;
 import static com.hcaptcha.sdk.AssertUtil.waitToBeDisplayed;
@@ -157,11 +158,17 @@ public class HCaptchaDialogFragmentTest {
 
     @Test
     public void loaderVisible() {
-        launchInContainer();
+        launchInContainer(
+                config,
+                internalConfig.toBuilder()
+                        .htmlProvider(new HCaptchaTestHtml(false))
+                        .build(),
+                new HCaptchaStateTestAdapter());
         onView(withId(R.id.loadingContainer)).perform(waitToBeDisplayed());
         onView(withId(R.id.loadingContainer)).check(matches(isDisplayed()));
         onView(withId(R.id.loadingContainer)).check(matches(withBackgroundColor(android.graphics.Color.WHITE)));
         onView(withId(R.id.webView)).perform(waitToBeDisplayed());
+        onView(withId(R.id.webView)).perform(evaluateJavascript("onHcaptchaLoaded()"));
         final long waitToDisappearMs = 10000;
         onView(withId(R.id.loadingContainer)).perform(waitToDisappear(waitToDisappearMs));
     }
@@ -470,6 +477,39 @@ public class HCaptchaDialogFragmentTest {
                         0 /* NO_META */);
                 assertTrue(dialog.dispatchTouchEvent(keyEvent));
             });
+        }
+    }
+
+    @Test
+    public void testInvisibleDialogDoesNotExecuteBeforeBridgeLoaded() throws InterruptedException {
+        final CountDownLatch loadedLatch = new CountDownLatch(1);
+        final CountDownLatch failureLatch = new CountDownLatch(1);
+        final HCaptchaStateListener listener = new HCaptchaStateTestAdapter() {
+            @Override
+            void onLoaded() {
+                loadedLatch.countDown();
+            }
+
+            @Override
+            void onFailure(HCaptchaException exception) {
+                failureLatch.countDown();
+            }
+        };
+
+        try (FragmentScenario<HCaptchaDialogFragment> scenario = launch(
+                config.toBuilder()
+                        .size(HCaptchaSize.INVISIBLE)
+                        .hideDialog(false)
+                        .build(),
+                internalConfig.toBuilder()
+                        .htmlProvider(new HCaptchaTestHtml(false, true))
+                        .build(),
+                listener)) {
+            assertFalse(loadedLatch.await(AWAIT_CALLBACK_MS, TimeUnit.MILLISECONDS));
+            assertFalse(failureLatch.await(AWAIT_CALLBACK_MS, TimeUnit.MILLISECONDS));
+            onView(withId(R.id.webView)).perform(evaluateJavascript("onHcaptchaLoaded()"));
+            assertTrue(loadedLatch.await(AWAIT_CALLBACK_MS, TimeUnit.MILLISECONDS));
+            assertTrue(failureLatch.await(AWAIT_CALLBACK_MS, TimeUnit.MILLISECONDS));
         }
     }
 

--- a/test/src/androidTest/java/com/hcaptcha/sdk/HCaptchaTest.java
+++ b/test/src/androidTest/java/com/hcaptcha/sdk/HCaptchaTest.java
@@ -1,5 +1,6 @@
 package com.hcaptcha.sdk;
 
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static com.hcaptcha.sdk.AssertUtil.waitHCaptchaWebViewToken;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -20,6 +21,7 @@ import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class HCaptchaTest {
     private static final long AWAIT_CALLBACK_MS = 5000;
@@ -124,6 +126,41 @@ public class HCaptchaTest {
                 .addOnFailureListener(exception -> fail("No errors expected")));
 
         assertTrue(latch.await(E2E_AWAIT_CALLBACK_MS, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void dialogVerifierReplaysLoadedAfterReset() throws Exception {
+        final CountDownLatch firstSuccessLatch = new CountDownLatch(1);
+        final CountDownLatch secondFailureLatch = new CountDownLatch(1);
+        final AtomicReference<HCaptcha> hCaptchaRef = new AtomicReference<>();
+
+        final HCaptchaInternalConfig resetAwareInternalConfig = internalConfig.toBuilder()
+                .htmlProvider(new HCaptchaTestHtml(true, false, true))
+                .build();
+        final HCaptchaConfig dialogConfig = config.toBuilder().hideDialog(false).build();
+
+        final ActivityScenario<TestActivity> scenario = rule.getScenario();
+        scenario.onActivity(activity -> {
+            final HCaptcha hCaptcha = HCaptcha.getClient(activity, resetAwareInternalConfig);
+            hCaptchaRef.set(hCaptcha);
+            hCaptcha.verifyWithHCaptcha(dialogConfig)
+                    .addOnSuccessListener(response -> firstSuccessLatch.countDown())
+                    .addOnFailureListener(exception -> {
+                        if (firstSuccessLatch.getCount() == 0
+                                && exception.getHCaptchaError() == HCaptchaError.ERROR) {
+                            secondFailureLatch.countDown();
+                        } else {
+                            fail("Unexpected failure: " + exception.getHCaptchaError());
+                        }
+                    });
+        });
+
+        waitHCaptchaWebViewToken(firstSuccessLatch, AWAIT_CALLBACK_MS);
+        getInstrumentation().waitForIdleSync();
+
+        scenario.onActivity(activity -> hCaptchaRef.get().verifyWithHCaptcha(dialogConfig));
+
+        assertTrue(secondFailureLatch.await(AWAIT_CALLBACK_MS, TimeUnit.MILLISECONDS));
     }
 
     @Test(expected = IllegalStateException.class)

--- a/test/src/androidTest/java/com/hcaptcha/sdk/HCaptchaTestHtml.java
+++ b/test/src/androidTest/java/com/hcaptcha/sdk/HCaptchaTestHtml.java
@@ -5,13 +5,25 @@ import androidx.annotation.NonNull;
 class HCaptchaTestHtml implements IHCaptchaHtmlProvider {
 
     private final boolean callBridgeOnLoaded;
+    private final boolean failOnExecute;
+    private final boolean failOnExecuteAfterReset;
 
     HCaptchaTestHtml() {
         this(true);
     }
 
     HCaptchaTestHtml(boolean callBridgeOnLoaded) {
+        this(callBridgeOnLoaded, false);
+    }
+
+    HCaptchaTestHtml(boolean callBridgeOnLoaded, boolean failOnExecute) {
+        this(callBridgeOnLoaded, failOnExecute, false);
+    }
+
+    HCaptchaTestHtml(boolean callBridgeOnLoaded, boolean failOnExecute, boolean failOnExecuteAfterReset) {
         this.callBridgeOnLoaded = callBridgeOnLoaded;
+        this.failOnExecute = failOnExecute;
+        this.failOnExecuteAfterReset = failOnExecuteAfterReset;
     }
 
     @Override
@@ -40,6 +52,7 @@ class HCaptchaTestHtml implements IHCaptchaHtmlProvider {
                 + "        console.assert(typeof window.JSDI.getSysDebug() === 'object');\n"
                 + "        var BridgeObject = window.JSInterface;\n"
                 + "        var bridgeConfig = JSON.parse(BridgeObject.getConfig());\n"
+                + "        var resetCount = 0;\n"
                 + "        function onHcaptchaLoaded() {\n"
                 + "            try {\n"
                 + "                BridgeObject.onLoaded();\n"
@@ -64,9 +77,13 @@ class HCaptchaTestHtml implements IHCaptchaHtmlProvider {
                 + "            TestObject.setData(JSON.stringify(arg));\n"
                 + "        }\n"
                 + "        function reset() {\n"
+                + "            resetCount += 1;\n"
                 + "            document.getElementById(\"input-text\").value = \"reset\";\n"
                 + "        }\n"
                 + "        function execute() {\n"
+                + (failOnExecute ? "            BridgeObject.onError(29);\n" : "")
+                + (failOnExecuteAfterReset
+                        ? "            if (resetCount > 1) { BridgeObject.onError(29); }\n" : "")
                 + "        }\n"
                 + (callBridgeOnLoaded ? "onHcaptchaLoaded();\n" : "")
                 + "    </script>\n"


### PR DESCRIPTION
## Summary
- gate `HCaptchaDialogFragment.onStart()` loaded replay so it only runs after the WebView has previously reported a real bridge load
- preserve the existing reuse-after-reset behavior for already-loaded WebViews
- prevent first dialog start from synthesizing `onLoaded()` before the JS SDK calls `BridgeObject.onLoaded()`

## Why
This is an SDK lifecycle bug, not a live-test-only flake. `onLoaded()` has side effects: it emits the loaded listener callback, sets verify params, and auto-executes invisible challenges. Calling it unconditionally from `onStart()` can run those effects before web content has actually reported loaded, which matches the generic error 29 failure seen in live CI.

The original replay path appears useful for reusing a loaded WebView after reset, so this keeps that behavior but arms it only after a real bridge load.

## Testing
- `./gradlew :sdk:check :test:compileDebugAndroidTestJavaWithJavac`
- repo pre-commit check ran successfully during commit
